### PR TITLE
DM-20580: Implement filling of empty fields with random data

### DIFF
--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -149,8 +149,8 @@ class ApdbCassandraSchema(ApdbBaseSchema):
             column_defs = ['"apdb_part" INT',
                            '"visitId" INT',
                            '"visitTime" TIMESTAMP',
-                           '"lastObjectId" INT',
-                           '"lastSourceId" INT',
+                           '"lastObjectId" BIGINT',
+                           '"lastSourceId" BIGINT',
                            'PRIMARY KEY ("apdb_part", "visitId")']
             return column_defs
 


### PR DESCRIPTION
Cassandra does not store NULL so for realistic test we need non-NULL
payload for all table columns. I added new configuration option for
Cassandra backend which fills columns that are not explicitly set with
random data. I'm doing it the backend instead of ap_proto because it is
much simplere to do here and I need a quick and dirty way to do it right
now. For final implementation we won't need it ao it will be removed
when we settle on what final implementation is going to look like.