### PR TITLE
DM-30985: Change schema file discovery to use environment variables and expandvars

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -36,7 +36,6 @@ import lsst.geom as geom
 import lsst.afw.table as afwTable
 import lsst.pex.config as pexConfig
 from lsst.pex.config import Field, ChoiceField, ListField
-from lsst.utils import getPackageDir
 import sqlalchemy
 from sqlalchemy import (func, sql)
 from sqlalchemy.pool import NullPool
@@ -124,7 +123,7 @@ def _ansi_session(engine):
 def _data_file_name(basename):
     """Return path name of a data file.
     """
-    return os.path.join(getPackageDir("dax_apdb"), "data", basename)
+    return os.path.join("${DAX_APDB_DIR}", "data", basename)
 
 
 class ApdbConfig(pexConfig.Config):

--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -28,6 +28,7 @@ __all__ = ["ColumnDef", "IndexDef", "TableDef",
 
 from collections import namedtuple
 import logging
+import os
 import yaml
 
 import sqlalchemy
@@ -234,6 +235,7 @@ class ApdbSchema(object):
         self.visits = None
 
         if column_map:
+            column_map = os.path.expandvars(column_map)
             _LOG.debug("Reading column map file %s", column_map)
             with open(column_map) as yaml_stream:
                 # maps cat column name to afw column name
@@ -494,6 +496,7 @@ class ApdbSchema(object):
             Mapping of table names to `TableDef` instances.
         """
 
+        schema_file = os.path.expandvars(schema_file)
         _LOG.debug("Reading schema file %s", schema_file)
         with open(schema_file) as yaml_stream:
             tables = list(yaml.load_all(yaml_stream, Loader=yaml.SafeLoader))
@@ -501,6 +504,7 @@ class ApdbSchema(object):
         _LOG.debug("Read %d tables from schema", len(tables))
 
         if extra_schema_file:
+            extra_schema_file = os.path.expandvars(extra_schema_file)
             _LOG.debug("Reading extra schema file %s", extra_schema_file)
             with open(extra_schema_file) as yaml_stream:
                 extras = list(yaml.load_all(yaml_stream, Loader=yaml.SafeLoader))


### PR DESCRIPTION
This changes the config items to support environment variables rather
than using getPackageDir. This allows runtime evaluation of the
file path rather than config read evaluation (which then gets
written to quantum graph files). This allows graph building to
run on a different system to the system that executes that graph.

This is required for lsst/ap_association#119