### PR TITLE
DM-31619: Fully incorporate SSP object association in DiaPipe

### DIFF
--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -772,7 +772,10 @@ class ApdbSql(Apdb):
             diaObjectId: pixelId for diaObjectId, pixelId
             in zip(objs["diaObjectId"], objs[self.config.htm_index_column])
         }
-
+        # DiaSources associated with SolarSystemObjects do not have an
+        # associated DiaObject hence we skip them and set their htmIndex
+        # value to 0.
+        pixel_id_map[0] = 0
         htm_index = np.zeros(sources.shape[0], dtype=np.int64)
         for i, diaObjId in enumerate(sources["diaObjectId"]):
             htm_index[i] = pixel_id_map[diaObjId]

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -70,8 +70,9 @@ def _makeObjectCatalogPandas(region, count: int, config: ApdbSqlConfig):
     object per pixel range). Coordinates of the created objects are not usable.
     """
     data_list = []
+    # 0 id'ed DiaObjects don't exist and is used as a Null value for the id.
     for oid, sp in enumerate(_makeVectors(region, count)):
-        tmp_dict = {"diaObjectId": oid,
+        tmp_dict = {"diaObjectId": oid + 1,
                     "ra": sp.getRa().asDegrees(),
                     "decl": sp.getDec().asDegrees()}
         data_list.append(tmp_dict)


### PR DESCRIPTION
Add htm skip for SolarSystem associated DiaSources

Modify test to start with 1 indexed ids for DiaObjects.