### PR TITLE
DM-33313: Add methods to support future PPDB replication

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -26,7 +26,7 @@ __all__ = ["ApdbConfig", "Apdb"]
 from abc import ABC, abstractmethod
 import os
 import pandas
-from typing import Iterable, Optional
+from typing import Iterable, Mapping, Optional
 
 import lsst.daf.base as dafBase
 from lsst.pex.config import Config, ConfigurableField, Field
@@ -201,6 +201,119 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def getDiaObjectsHistory(self,
+                             start_time: dafBase.DateTime,
+                             end_time: Optional[dafBase.DateTime] = None,
+                             region: Optional[Region] = None) -> pandas.DataFrame:
+        """Returns catalog of DiaObject instances from a given time period
+        including the history of each DiaObject.
+
+        Parameters
+        ----------
+        start_time : `dafBase.DateTime`
+            Starting time for DiaObject history search. DiaObject record is
+            selected when its ``validityStart`` falls into an interval
+            between ``start__time`` (inclusive) and ``end_time`` (exclusive).
+        end_time : `dafBase.DateTime`, optional
+            Upper limit on time for DiaObject history search, if not specified
+            then there is no restriction on upper limit.
+        region : `lsst.sphgeom.Region`, optional
+            Region to search for DiaObjects, if not specified then whole sky
+            is searched. If region is specified then some returned records may
+            fall outside of this region.
+
+        Returns
+        -------
+        catalog : `pandas.DataFrame`
+            Catalog containing DiaObject records.
+
+        Notes
+        -----
+        This part of API may not be very stable and can change before the
+        implementation finalizes.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def getDiaSourcesHistory(self,
+                             start_time: dafBase.DateTime,
+                             end_time: Optional[dafBase.DateTime] = None,
+                             region: Optional[Region] = None) -> pandas.DataFrame:
+        """Returns catalog of DiaSource instances from a given time period.
+
+        Parameters
+        ----------
+        start_time : `dafBase.DateTime`
+            Starting time for DiaSource history search. DiaSource record is
+            selected when its ``midPointTai`` falls into an interval between
+            ``start__time`` (inclusive) and ``end_time`` (exclusive).
+        end_time : `dafBase.DateTime`
+            Upper limit on time for DiaSource history search, if not specified
+            then there is no restriction on upper limit.
+        region : `lsst.sphgeom.Region`, optional
+            Region to search for DiaSources, if not specified then whole sky
+            is searched. If region is specified then some returned records may
+            fall outside of this region.
+
+        Returns
+        -------
+        catalog : `pandas.DataFrame`
+            Catalog containing DiaObject records.
+
+        Notes
+        -----
+        This part of API may not be very stable and can change before the
+        implementation finalizes.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def getDiaForcedSourcesHistory(self,
+                                   start_time: dafBase.DateTime,
+                                   end_time: Optional[dafBase.DateTime] = None,
+                                   region: Optional[Region] = None) -> pandas.DataFrame:
+        """Returns catalog of DiaForcedSource instances from a given time
+        period.
+
+        Parameters
+        ----------
+        start_time : `dafBase.DateTime`
+            Starting time for DiaForcedSource history search. DiaForcedSource
+            record is selected when its ``midPointTai`` falls into an interval
+            between ``start__time`` (inclusive) and ``end_time`` (exclusive).
+        end_time : `dafBase.DateTime`
+            Upper limit on time for DiaForcedSource history search, if not
+            specified then there is no restriction on upper limit.
+        region : `lsst.sphgeom.Region`, optional
+            Region to search for DiaForcedSources, if not specified then whole
+            sky is searched. If region is specified then some returned records
+            may fall outside of this region.
+
+        Returns
+        -------
+        catalog : `pandas.DataFrame`
+            Catalog containing DiaObject records.
+
+        Notes
+        -----
+        This part of API may not be very stable and can change before the
+        implementation finalizes.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def getSSObjects(self) -> pandas.DataFrame:
+        """Returns catalog of SSObject instances.
+
+        Returns
+        -------
+        catalog : `pandas.DataFrame`
+            Catalog containing SSObject records, all existing records are
+            returned.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def store(self,
               visit_time: dafBase.DateTime,
               objects: pandas.DataFrame,
@@ -234,6 +347,34 @@ class Apdb(ABC):
             catalog
           - source catalogs have ``diaObjectId`` column associating sources
             with objects
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def storeSSObjects(self, objects: pandas.DataFrame) -> None:
+        """Store or update SSObject catalog.
+
+        Parameters
+        ----------
+        objects : `pandas.DataFrame`
+            Catalog with SSObject records.
+
+        Notes
+        -----
+        If SSObjects with matching IDs already exist in the database, their
+        records will be updated with the information from provided records.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def reassignDiaSources(self, idMap: Mapping[int, int]) -> None:
+        """Associate DiaSources with SSObjects, dis-associating them
+        from DiaObjects.
+
+        Parameters
+        ----------
+        idMap : `Mapping`
+            Maps DiaSource IDs to their new SSObject IDs.
         """
         raise NotImplementedError()
 

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -635,6 +635,31 @@ class ApdbCassandra(Apdb):
         _LOG.debug("found %d %ss", catalog.shape[0], table_name.name)
         return catalog
 
+    def getDiaObjectsHistory(self,
+                             start_time: dafBase.DateTime,
+                             end_time: Optional[dafBase.DateTime] = None,
+                             region: Optional[sphgeom.Region] = None) -> pandas.DataFrame:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
+    def getDiaSourcesHistory(self,
+                             start_time: dafBase.DateTime,
+                             end_time: Optional[dafBase.DateTime] = None,
+                             region: Optional[sphgeom.Region] = None) -> pandas.DataFrame:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
+    def getDiaForcedSourcesHistory(self,
+                                   start_time: dafBase.DateTime,
+                                   end_time: Optional[dafBase.DateTime] = None,
+                                   region: Optional[sphgeom.Region] = None) -> pandas.DataFrame:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
+    def getSSObjects(self) -> pandas.DataFrame:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
     def store(self,
               visit_time: dafBase.DateTime,
               objects: pandas.DataFrame,
@@ -697,6 +722,14 @@ class ApdbCassandra(Apdb):
 
         self._storeObjectsPandas(sources, table_name, visit_time,
                                  extra_columns=extra_columns, time_part=time_part)
+
+    def storeSSObjects(self, objects: pandas.DataFrame) -> None:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
+    def reassignDiaSources(self, idMap: Mapping[int, int]) -> None:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
 
     def dailyJob(self) -> None:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/apdbSqlSchema.py
+++ b/python/lsst/dax/apdb/apdbSqlSchema.py
@@ -102,7 +102,7 @@ class ApdbSqlSchema(ApdbSchema):
             tableDef = self.tableSchemas.get(table)
             if not tableDef:
                 continue
-            column = ColumnDef(name="pixelId",
+            column = ColumnDef(name=htm_index_column,
                                type="BIGINT",
                                nullable=False,
                                default=None,
@@ -113,11 +113,11 @@ class ApdbSqlSchema(ApdbSchema):
 
             if table is ApdbTables.DiaObjectLast:
                 # use it as a leading PK column
-                tableDef.primary_key.columns.insert(0, "pixelId")
+                tableDef.primary_key.columns.insert(0, htm_index_column)
             else:
                 # make a regular index
-                index = IndexDef(name=f"IDX_{tableDef.name}_pixelId",
-                                 type=IndexType.INDEX, columns=["pixelId"])
+                index = IndexDef(name=f"IDX_{tableDef.name}_{htm_index_column}",
+                                 type=IndexType.INDEX, columns=[htm_index_column])
                 tableDef.indices.append(index)
 
         # generate schema for all tables, must be called last
@@ -127,6 +127,7 @@ class ApdbSqlSchema(ApdbSchema):
         self.objects_last = self._tables.get(ApdbTables.DiaObjectLast)
         self.sources = self._tables[ApdbTables.DiaSource]
         self.forcedSources = self._tables[ApdbTables.DiaForcedSource]
+        self.ssObjects = self._tables[ApdbTables.SSObject]
 
     def _makeTables(self, mysql_engine: str = 'InnoDB') -> Mapping[ApdbTables, Table]:
         """Generate schema for all tables.

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -61,7 +61,7 @@ def _genPointsInRegion(region: Region, count: int) -> Iterator[SpherePoint]:
             count -= 1
 
 
-def makeObjectCatalog(region: Region, count: int) -> pandas.DataFrame:
+def makeObjectCatalog(region: Region, count: int, start_id: int = 1) -> pandas.DataFrame:
     """Make a catalog containing a bunch of DiaObjects inside a region.
 
     Parameters
@@ -84,7 +84,7 @@ def makeObjectCatalog(region: Region, count: int) -> pandas.DataFrame:
     points = list(_genPointsInRegion(region, count))
     # diaObjectId=0 may be used in some code for DiaSource foreign key to mean
     # the same as ``None``.
-    ids = numpy.arange(1, len(points) + 1, dtype=numpy.int64)
+    ids = numpy.arange(start_id, len(points) + start_id, dtype=numpy.int64)
     ras = numpy.array([sp.getRa().asDegrees() for sp in points], dtype=numpy.float64)
     decls = numpy.array([sp.getDec().asDegrees() for sp in points], dtype=numpy.float64)
     df = pandas.DataFrame({"diaObjectId": ids,
@@ -135,7 +135,7 @@ def makeSourceCatalog(objects: pandas.DataFrame, visit_time: DateTime,
 
 def makeForcedSourceCatalog(objects: pandas.DataFrame, visit_time: DateTime,
                             ccdVisitId: int = 1) -> pandas.DataFrame:
-    """Make a catalog containing a bunch of DiaFourceSources associated with
+    """Make a catalog containing a bunch of DiaForcedSources associated with
     the input DiaObjects.
 
     Parameters
@@ -164,4 +164,35 @@ def makeForcedSourceCatalog(objects: pandas.DataFrame, visit_time: DateTime,
         "midPointTai": numpy.full(nrows, midPointTai, dtype=numpy.float64),
         "flags": numpy.full(nrows, 0, dtype=numpy.int64),
     })
+    return df
+
+
+def makeSSObjectCatalog(count: int, start_id: int = 1, flags: int = 0) -> pandas.DataFrame:
+    """Make a catalog containing a bunch of SSObjects.
+
+    Parameters
+    ----------
+    count : `int`
+        Number of records to generate.
+    startID : `int`
+        Initial SSObject ID.
+    flags : `int`
+        Value for ``flags`` column.
+
+    Returns
+    -------
+    catalog : `pandas.DataFrame`
+        Catalog of SSObjects records.
+
+    Notes
+    -----
+    Returned catalog only contains three columns - ``ssObjectId`, ``arc``,
+    and ``flags``.
+    """
+    ids = numpy.arange(start_id, count + start_id, dtype=numpy.int64)
+    arc = numpy.full(count, 0.001, dtype=numpy.float32)
+    flags = numpy.full(count, flags, dtype=numpy.int64)
+    df = pandas.DataFrame({"ssObjectId": ids,
+                           "arc": arc,
+                           "flags": flags})
     return df

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -110,10 +110,6 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
     def n_columns(self, table: ApdbTables) -> int:
         """Return number of columns for a specified table."""
 
-        if table is ApdbTables.DiaObject:
-            # DiaObjectLast is used
-            table = ApdbTables.DiaObjectLast
-
         # Tables add one or two partitioning columns depending on config
         if table is ApdbTables.DiaObjectLast:
             n_part_columns = 1
@@ -131,6 +127,10 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
             return self.n_src_columns + n_part_columns
         elif table is ApdbTables.DiaForcedSource:
             return self.n_fsrc_columns + n_part_columns
+
+    def getDiaObjects_table(self) -> ApdbTables:
+        """Return type of table returned from getDiaObjects method."""
+        return ApdbTables.DiaObjectLast
 
 
 class ApdbCassandraPerMonthTestCase(ApdbCassandraTestCase):

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -49,10 +49,6 @@ class ApdbSqlTestCase(unittest.TestCase, ApdbTest):
     def n_columns(self, table: ApdbTables) -> int:
         """Return number of columns for a specified table."""
 
-        if table is ApdbTables.DiaObject and self.dia_object_index == "last_object_table":
-            # DiaObjectLast is used
-            table = ApdbTables.DiaObjectLast
-
         # Some tables add pixelId column to standard schema
         if table is ApdbTables.DiaObject:
             return self.n_obj_columns + 1
@@ -62,6 +58,12 @@ class ApdbSqlTestCase(unittest.TestCase, ApdbTest):
             return self.n_src_columns + 1
         elif table is ApdbTables.DiaForcedSource:
             return self.n_fsrc_columns
+        elif table is ApdbTables.SSObject:
+            return self.n_ssobj_columns
+
+    def getDiaObjects_table(self) -> ApdbTables:
+        """Return type of table returned from getDiaObjects method."""
+        return ApdbTables.DiaObject
 
 
 class ApdbSqlTestCaseLastObject(ApdbSqlTestCase):
@@ -69,6 +71,10 @@ class ApdbSqlTestCaseLastObject(ApdbSqlTestCase):
     """
 
     dia_object_index = "last_object_table"
+
+    def getDiaObjects_table(self) -> ApdbTables:
+        """Return type of table returned from getDiaObjects method."""
+        return ApdbTables.DiaObjectLast
 
 
 class ApdbSqlTestCasePixIdIovIndex(ApdbSqlTestCase):


### PR DESCRIPTION
Apdb interface was extended with few methods that will be needed for the
replication to/from PPDB. SQL implemention has these new methods working
but Cassandra implementation will be done on a separate ticket (it needs
schema extension and some experimenting). This new interface may still
change when the replication system implementation starts.