### PR TITLE
DM-33314: Implement missing methods for Cassandra backend

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -372,6 +372,11 @@ class Apdb(ABC):
         ----------
         idMap : `Mapping`
             Maps DiaSource IDs to their new SSObject IDs.
+
+        Raises
+        ------
+        ValueError
+            Raised if DiaSource ID does not exist in the database.
         """
         raise NotImplementedError()
 

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -294,7 +294,8 @@ class Apdb(ABC):
         Notes
         -----
         This part of API may not be very stable and can change before the
-        implementation finalizes.
+        implementation finalizes. Some implementations may not support region
+        filtering, they will return records from the whole sky.
         """
         raise NotImplementedError()
 

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -203,7 +203,7 @@ class Apdb(ABC):
     @abstractmethod
     def getDiaObjectsHistory(self,
                              start_time: dafBase.DateTime,
-                             end_time: Optional[dafBase.DateTime] = None,
+                             end_time: dafBase.DateTime,
                              region: Optional[Region] = None) -> pandas.DataFrame:
         """Returns catalog of DiaObject instances from a given time period
         including the history of each DiaObject.
@@ -213,10 +213,9 @@ class Apdb(ABC):
         start_time : `dafBase.DateTime`
             Starting time for DiaObject history search. DiaObject record is
             selected when its ``validityStart`` falls into an interval
-            between ``start__time`` (inclusive) and ``end_time`` (exclusive).
-        end_time : `dafBase.DateTime`, optional
-            Upper limit on time for DiaObject history search, if not specified
-            then there is no restriction on upper limit.
+            between ``start_time`` (inclusive) and ``end_time`` (exclusive).
+        end_time : `dafBase.DateTime`
+            Upper limit on time for DiaObject history search.
         region : `lsst.sphgeom.Region`, optional
             Region to search for DiaObjects, if not specified then whole sky
             is searched. If region is specified then some returned records may
@@ -237,7 +236,7 @@ class Apdb(ABC):
     @abstractmethod
     def getDiaSourcesHistory(self,
                              start_time: dafBase.DateTime,
-                             end_time: Optional[dafBase.DateTime] = None,
+                             end_time: dafBase.DateTime,
                              region: Optional[Region] = None) -> pandas.DataFrame:
         """Returns catalog of DiaSource instances from a given time period.
 
@@ -246,10 +245,9 @@ class Apdb(ABC):
         start_time : `dafBase.DateTime`
             Starting time for DiaSource history search. DiaSource record is
             selected when its ``midPointTai`` falls into an interval between
-            ``start__time`` (inclusive) and ``end_time`` (exclusive).
+            ``start_time`` (inclusive) and ``end_time`` (exclusive).
         end_time : `dafBase.DateTime`
-            Upper limit on time for DiaSource history search, if not specified
-            then there is no restriction on upper limit.
+            Upper limit on time for DiaSource history search.
         region : `lsst.sphgeom.Region`, optional
             Region to search for DiaSources, if not specified then whole sky
             is searched. If region is specified then some returned records may
@@ -270,7 +268,7 @@ class Apdb(ABC):
     @abstractmethod
     def getDiaForcedSourcesHistory(self,
                                    start_time: dafBase.DateTime,
-                                   end_time: Optional[dafBase.DateTime] = None,
+                                   end_time: dafBase.DateTime,
                                    region: Optional[Region] = None) -> pandas.DataFrame:
         """Returns catalog of DiaForcedSource instances from a given time
         period.
@@ -280,10 +278,9 @@ class Apdb(ABC):
         start_time : `dafBase.DateTime`
             Starting time for DiaForcedSource history search. DiaForcedSource
             record is selected when its ``midPointTai`` falls into an interval
-            between ``start__time`` (inclusive) and ``end_time`` (exclusive).
+            between ``start_time`` (inclusive) and ``end_time`` (exclusive).
         end_time : `dafBase.DateTime`
-            Upper limit on time for DiaForcedSource history search, if not
-            specified then there is no restriction on upper limit.
+            Upper limit on time for DiaForcedSource history search.
         region : `lsst.sphgeom.Region`, optional
             Region to search for DiaForcedSources, if not specified then whole
             sky is searched. If region is specified then some returned records

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -175,7 +175,7 @@ class ApdbCassandraSchema(ApdbSchema):
         Returns
         -------
         columns : `list` of `str`
-            Names of columns for used for partitioning.
+            Names of columns for used for clustering.
         """
         table_schema = self.tableSchemas[table_name]
         for index in table_schema.indices:

--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -67,13 +67,13 @@ class ColumnDef:
     """name of cat type (INT, FLOAT, etc.)"""
     nullable: bool
     """True for nullable columns"""
-    default: Any
+    default: Any = None
     """default value for column, can be None"""
-    description: Optional[str]
+    description: Optional[str] = None
     """documentation, can be None or empty"""
-    unit: Optional[str]
+    unit: Optional[str] = None
     """string with unit name, can be None"""
-    ucd: Optional[str]
+    ucd: Optional[str] = None
     """string with ucd, can be None"""
 
     @property
@@ -110,12 +110,12 @@ class TableDef:
     """
     name: str
     """table name"""
-    description: Optional[str]
-    """documentation, can be None or empty"""
     columns: List[ColumnDef]
     """list of ColumnDef instances"""
     indices: List[IndexDef]
     """list of IndexDef instances, can be empty"""
+    description: Optional[str] = None
+    """documentation, can be None or empty"""
 
     @property
     def primary_key(self) -> IndexDef:

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -393,7 +393,7 @@ class ApdbSql(Apdb):
 
     def getDiaObjectsHistory(self,
                              start_time: dafBase.DateTime,
-                             end_time: Optional[dafBase.DateTime] = None,
+                             end_time: dafBase.DateTime,
                              region: Optional[Region] = None) -> pandas.DataFrame:
         # docstring is inherited from a base class
 
@@ -401,12 +401,10 @@ class ApdbSql(Apdb):
         query = table.select()
 
         # build selection
-        time_filter = table.columns["validityStart"] >= start_time.toPython()
-        if end_time:
-            time_filter = sql.expression.and_(
-                time_filter,
-                table.columns["validityStart"] < end_time.toPython()
-            )
+        time_filter = sql.expression.and_(
+            table.columns["validityStart"] >= start_time.toPython(),
+            table.columns["validityStart"] < end_time.toPython()
+        )
 
         if region:
             where = sql.expression.and_(self._filterRegion(table, region), time_filter)
@@ -423,7 +421,7 @@ class ApdbSql(Apdb):
 
     def getDiaSourcesHistory(self,
                              start_time: dafBase.DateTime,
-                             end_time: Optional[dafBase.DateTime] = None,
+                             end_time: dafBase.DateTime,
                              region: Optional[Region] = None) -> pandas.DataFrame:
         # docstring is inherited from a base class
 
@@ -431,12 +429,10 @@ class ApdbSql(Apdb):
         query = table.select()
 
         # build selection
-        time_filter = table.columns["midPointTai"] >= start_time.get(system=dafBase.DateTime.MJD)
-        if end_time:
-            time_filter = sql.expression.and_(
-                time_filter,
-                table.columns["midPointTai"] < end_time.get(system=dafBase.DateTime.MJD)
-            )
+        time_filter = sql.expression.and_(
+            table.columns["midPointTai"] >= start_time.get(system=dafBase.DateTime.MJD),
+            table.columns["midPointTai"] < end_time.get(system=dafBase.DateTime.MJD)
+        )
 
         if region:
             where = sql.expression.and_(self._filterRegion(table, region), time_filter)
@@ -453,7 +449,7 @@ class ApdbSql(Apdb):
 
     def getDiaForcedSourcesHistory(self,
                                    start_time: dafBase.DateTime,
-                                   end_time: Optional[dafBase.DateTime] = None,
+                                   end_time: dafBase.DateTime,
                                    region: Optional[Region] = None) -> pandas.DataFrame:
         # docstring is inherited from a base class
 
@@ -461,12 +457,10 @@ class ApdbSql(Apdb):
         query = table.select()
 
         # build selection
-        time_filter = table.columns["midPointTai"] >= start_time.get(system=dafBase.DateTime.MJD)
-        if end_time:
-            time_filter = sql.expression.and_(
-                time_filter,
-                table.columns["midPointTai"] < end_time.get(system=dafBase.DateTime.MJD)
-            )
+        time_filter = sql.expression.and_(
+            table.columns["midPointTai"] >= start_time.get(system=dafBase.DateTime.MJD),
+            table.columns["midPointTai"] < end_time.get(system=dafBase.DateTime.MJD)
+        )
         # Forced sources have no pixel index, so no region filtering
         query = query.where(time_filter)
 

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -30,7 +30,7 @@ from contextlib import contextmanager
 import logging
 import numpy as np
 import pandas
-from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
+from typing import cast, Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 
 import lsst.daf.base as dafBase
 from lsst.pex.config import Field, ChoiceField, ListField
@@ -529,8 +529,8 @@ class ApdbSql(Apdb):
             knownIds = set(row[idColumn] for row in result)
 
             filter = objects[idColumn].isin(knownIds)
-            toUpdate = objects[filter]
-            toInsert = objects[~filter]
+            toUpdate = cast(pandas.DataFrame, objects[filter])
+            toInsert = cast(pandas.DataFrame, objects[~filter])
 
             # insert new records
             if len(toInsert) > 0:

--- a/python/lsst/dax/apdb/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra_utils.py
@@ -1,0 +1,266 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = [
+    "literal",
+    "pandas_dataframe_factory",
+    "quote_id",
+    "raw_data_factory",
+    "select_concurrent",
+]
+
+import logging
+import numpy as np
+import pandas
+from datetime import datetime, timedelta
+from typing import Any, List, Tuple, Union
+
+# If cassandra-driver is not there the module can still be imported
+# but things will not work.
+try:
+    from cassandra.cluster import EXEC_PROFILE_DEFAULT, Session
+    from cassandra.concurrent import execute_concurrent
+
+    CASSANDRA_IMPORTED = True
+except ImportError:
+    CASSANDRA_IMPORTED = False
+
+
+_LOG = logging.getLogger(__name__)
+
+
+if CASSANDRA_IMPORTED:
+
+    class SessionWrapper:
+        """Special wrapper class to workaround ``execute_concurrent()`` issue
+        which does not allow non-default execution profile.
+
+        Instance of this class can be passed to execute_concurrent() instead
+        of `Session` instance. This class implements a small set of methods
+        that are needed by ``execute_concurrent()``. When
+        ``execute_concurrent()`` is fixed to accept exectution profiles, this
+        wrapper can be dropped.
+        """
+
+        def __init__(
+            self, session: Session, execution_profile: Any = EXEC_PROFILE_DEFAULT
+        ):
+            self._session = session
+            self._execution_profile = execution_profile
+
+        def execute_async(
+            self,
+            *args: Any,
+            execution_profile: Any = EXEC_PROFILE_DEFAULT,
+            **kwargs: Any,
+        ) -> Any:
+            # explicit parameter can override our settings
+            if execution_profile is EXEC_PROFILE_DEFAULT:
+                execution_profile = self._execution_profile
+            return self._session.execute_async(
+                *args, execution_profile=execution_profile, **kwargs
+            )
+
+        def submit(self, *args: Any, **kwargs: Any) -> Any:
+            # internal method
+            return self._session.submit(*args, **kwargs)
+
+
+def pandas_dataframe_factory(
+    colnames: List[str], rows: List[Tuple]
+) -> pandas.DataFrame:
+    """Special non-standard row factory that creates pandas DataFrame from
+    Cassandra result set.
+
+    Parameters
+    ----------
+    colnames : `list` [ `str` ]
+        Names of the columns.
+    rows : `list` of `tuple`
+        Result rows.
+
+    Returns
+    -------
+    catalog : `pandas.DataFrame`
+        DataFrame with the result set.
+
+    Notes
+    -----
+    When using this method as row factory for Cassandra, the resulting
+    DataFrame should be accessed in a non-standard way using
+    `ResultSet._current_rows` attribute.
+    """
+    return pandas.DataFrame.from_records(rows, columns=colnames)
+
+
+def raw_data_factory(
+    colnames: List[str], rows: List[Tuple]
+) -> Tuple[List[str], List[Tuple]]:
+    """Special non-standard row factory that makes 2-element tuple containing
+    unmodified data: list of column names and list of rows.
+
+    Parameters
+    ----------
+    colnames : `list` [ `str` ]
+        Names of the columns.
+    rows : `list` of `tuple`
+        Result rows.
+
+    Returns
+    -------
+    colnames : `list` [ `str` ]
+        Names of the columns.
+    rows : `list` of `tuple`
+        Result rows
+
+    Notes
+    -----
+    When using this method as row factory for Cassandra, the resulting
+    2-element tuple should be accessed in a non-standard way using
+    `ResultSet._current_rows` attribute. This factory is used to build
+    pandas DataFrames in `select_concurrent` method.
+    """
+    return (colnames, rows)
+
+
+def select_concurrent(
+    session: Session, statements: List[Tuple], execution_profile: str, concurrency: int
+) -> Union[pandas.DataFrame, List]:
+    """Execute bunch of queries concurrently and merge their results into
+    a single result.
+
+    Parameters
+    ----------
+    statements : `list` [ `tuple` ]
+        List of statements and their parameters, passed directly to
+        ``execute_concurrent()``.
+    execution_profile : `str`
+        Execution profile name.
+
+    Returns
+    -------
+    result
+        Combined result of multiple statements, type of the result depends on
+        specific row factory defined in execution profile. If row factory is
+        one of `pandas_dataframe_factory` or `raw_data_factory` then pandas
+        DataFrame is created from a combined result. Otherwise a list of
+        rows is returned, type of each row is determined by the row factory.
+
+    Notes
+    -----
+    This method can raise any exception that is raised by one of the provided
+    statements.
+    """
+    session_wrap = SessionWrapper(session, execution_profile)
+    results = execute_concurrent(
+        session_wrap,
+        statements,
+        results_generator=True,
+        raise_on_first_error=False,
+        concurrency=concurrency,
+    )
+
+    ep = session.get_execution_profile(execution_profile)
+    if ep.row_factory is raw_data_factory:
+
+        # Collect rows into a single list and build Dataframe out of that
+        _LOG.debug("making pandas data frame out of rows/columns")
+        columns: Any = None
+        rows = []
+        for success, result in results:
+            if success:
+                result = result._current_rows
+                if columns is None:
+                    columns = result[0]
+                elif columns != result[0]:
+                    _LOG.error(
+                        "different columns returned by queries: %s and %s",
+                        columns,
+                        result[0],
+                    )
+                    raise ValueError(
+                        f"different columns returned by queries: {columns} and {result[0]}"
+                    )
+                rows += result[1]
+            else:
+                _LOG.error("error returned by query: %s", result)
+                raise result
+        catalog = pandas_dataframe_factory(columns, rows)
+        _LOG.debug("pandas catalog shape: %s", catalog.shape)
+        return catalog
+
+    elif ep.row_factory is pandas_dataframe_factory:
+
+        # Merge multiple DataFrames into one
+        _LOG.debug("making pandas data frame out of set of data frames")
+        dataframes = []
+        for success, result in results:
+            if success:
+                dataframes.append(result._current_rows)
+            else:
+                _LOG.error("error returned by query: %s", result)
+                raise result
+        # concatenate all frames
+        if len(dataframes) == 1:
+            catalog = dataframes[0]
+        else:
+            catalog = pandas.concat(dataframes)
+        _LOG.debug("pandas catalog shape: %s", catalog.shape)
+        return catalog
+
+    else:
+
+        # Just concatenate all rows into a single collection.
+        rows = []
+        for success, result in results:
+            if success:
+                rows.extend(result)
+            else:
+                _LOG.error("error returned by query: %s", result)
+                raise result
+        _LOG.debug("number of rows: %s", len(rows))
+        return rows
+
+
+def literal(v: Any) -> Any:
+    """Transform object into a value for the query."""
+    if v is None:
+        pass
+    elif isinstance(v, datetime):
+        v = int((v - datetime(1970, 1, 1)) / timedelta(seconds=1)) * 1000
+    elif isinstance(v, (bytes, str)):
+        pass
+    else:
+        try:
+            if not np.isfinite(v):
+                v = None
+        except TypeError:
+            pass
+    return v
+
+
+def quote_id(columnName: str) -> str:
+    """Smart quoting for column names. Lower-case names are not quoted."""
+    if not columnName.islower():
+        columnName = '"' + columnName + '"'
+    return columnName

--- a/python/lsst/dax/apdb/pixelization.py
+++ b/python/lsst/dax/apdb/pixelization.py
@@ -1,0 +1,108 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["Pixelization"]
+
+import logging
+from typing import List, Tuple
+
+from lsst import sphgeom
+
+
+_LOG = logging.getLogger(__name__)
+
+
+class Pixelization:
+    """Wrapper for pixelization classes from `sphgeom` with configurable
+    pixelization type and parameters.
+
+    Parameters
+    ----------
+    pixelization : `str`
+        Name of a pixelization type, one of ""htm", "q3c", or "mq3c"
+    pix_level : `int`
+        Pixelization level.
+    pix_max_ranges : `int`
+        Maximum number of ranges returned from `envelope()` method.
+    """
+
+    def __init__(self, pixelization: str, pix_level: int, pix_max_ranges: int):
+        if pixelization == "htm":
+            self.pixelator = sphgeom.HtmPixelization(pix_level)
+        elif pixelization == "q3c":
+            self.pixelator = sphgeom.Q3cPixelization(pix_level)
+        elif pixelization == "mq3c":
+            self.pixelator = sphgeom.Mq3cPixelization(pix_level)
+        else:
+            raise ValueError(f"unknown pixelization: {pixelization}")
+        self._pix_max_ranges = pix_max_ranges
+
+    def pixels(self, region: sphgeom.Region) -> List[int]:
+        """Compute set of the pixel indices for given region.
+
+        Parameters
+        ----------
+        region : `lsst.sphgeom.Region`
+        """
+        # we want finest set of pixels, so ask as many pixel as possible
+        ranges = self.pixelator.envelope(region, 1_000_000)
+        indices = []
+        for lower, upper in ranges:
+            indices += list(range(lower, upper))
+        return indices
+
+    def pixel(self, direction: sphgeom.UnitVector3d) -> int:
+        """Compute the index of the pixel for given direction.
+
+        Parameters
+        ----------
+        direction : `lsst.sphgeom.UnitVector3d`
+        """
+        index = self.pixelator.index(direction)
+        return index
+
+    def envelope(self, region: sphgeom.Region) -> List[Tuple[int, int]]:
+        """Generate a set of HTM indices covering specified region.
+
+        Parameters
+        ----------
+        region: `sphgeom.Region`
+            Region that needs to be indexed.
+
+        Returns
+        -------
+        ranges : `list` of `tuple`
+            Sequence of ranges, range is a tuple (minHtmID, maxHtmID).
+        """
+        _LOG.debug("region: %s", region)
+        indices = self.pixelator.envelope(region, self._pix_max_ranges)
+
+        if _LOG.isEnabledFor(logging.DEBUG):
+            for irange in indices.ranges():
+                _LOG.debug(
+                    "range: %s %s",
+                    self.pixelator.toString(irange[0]),
+                    self.pixelator.toString(irange[1]),
+                )
+
+        return indices.ranges()

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -224,6 +224,7 @@ class ApdbTest(ABC):
             DateTime("2021-01-01T00:05:00", DateTime.TAI),
             DateTime("2021-01-01T00:06:00", DateTime.TAI)
         ]
+        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
 
         nobj = 100
         catalog1 = makeObjectCatalog(region1, nobj)
@@ -236,22 +237,22 @@ class ApdbTest(ABC):
         apdb.store(visit_time[5], catalog2)
 
         # read it back and check sizes
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 5, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 4, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 2, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI))
+        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(
@@ -272,10 +273,14 @@ class ApdbTest(ABC):
         )
         self.assert_catalog(res, 0, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), region=region1)
+        res = apdb.getDiaObjectsHistory(
+            DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
+        )
         self.assert_catalog(res, nobj * 3, ApdbTables.DiaObject)
 
-        res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:03:00", DateTime.TAI), region=region2)
+        res = apdb.getDiaObjectsHistory(
+            DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
+        )
         self.assert_catalog(res, nobj * 2, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(
@@ -336,6 +341,7 @@ class ApdbTest(ABC):
             (DateTime("2021-01-01T00:05:00", DateTime.TAI), objects1),
             (DateTime("2021-01-01T00:06:00", DateTime.TAI), objects2),
         ]
+        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
 
         start_id = 0
         for visit_time, objects in visits:
@@ -344,22 +350,22 @@ class ApdbTest(ABC):
             start_id += nobj
 
         # read it back and check sizes
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 5, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 4, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 2, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI))
+        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(
@@ -380,10 +386,14 @@ class ApdbTest(ABC):
         )
         self.assert_catalog(res, 0, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), region=region1)
+        res = apdb.getDiaSourcesHistory(
+            DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
+        )
         self.assert_catalog(res, nobj * 3, ApdbTables.DiaSource)
 
-        res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:03:00", DateTime.TAI), region=region2)
+        res = apdb.getDiaSourcesHistory(
+            DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
+        )
         self.assert_catalog(res, nobj * 2, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(
@@ -440,6 +450,7 @@ class ApdbTest(ABC):
             (DateTime("2021-01-01T00:05:00", DateTime.TAI), objects1),
             (DateTime("2021-01-01T00:06:00", DateTime.TAI), objects2),
         ]
+        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
 
         start_id = 0
         for visit_time, objects in visits:
@@ -448,22 +459,22 @@ class ApdbTest(ABC):
             start_id += 1
 
         # read it back and check sizes
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 5, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 4, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
         self.assert_catalog(res, nobj * 2, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI))
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(
@@ -484,10 +495,14 @@ class ApdbTest(ABC):
         )
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), region=region1)
+        res = apdb.getDiaForcedSourcesHistory(
+            DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
+        )
         self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
 
-        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:03:00", DateTime.TAI), region=region2)
+        res = apdb.getDiaForcedSourcesHistory(
+            DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
+        )
         self.assert_catalog(res, nobj * 4, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -520,8 +520,8 @@ class ApdbTest(ABC):
         apdb.storeSSObjects(catalog)
         res = apdb.getSSObjects()
         self.assert_catalog(res, 150, ApdbTables.SSObject)
-        self.assertEqual(len(res[res["flags"] == 1]), 50)
-        self.assertEqual(len(res[res["flags"] == 2]), 100)
+        self.assertEqual(len(res[res["flags"] == 1]), 50)  # type: ignore[attr-defined]
+        self.assertEqual(len(res[res["flags"] == 2]), 100)  # type: ignore[attr-defined]
 
     def test_reassignObjects(self) -> None:
         """Reassign DiaObjects."""

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -564,6 +564,10 @@ class ApdbTest(ABC):
         res = apdb.getDiaSources(region, oids, visit_time)
         self.assert_catalog(res, len(sources) - 3, ApdbTables.DiaSource)
 
+        with self.assertRaisesRegex(ValueError, r"do not exist.*\D1000"):  # type: ignore[attr-defined]
+            apdb.reassignDiaSources({1000: 1, 7: 3, })
+        self.assert_catalog(res, len(sources) - 3, ApdbTables.DiaSource)
+
     def test_midPointTai_src(self) -> None:
         """Test for time filtering of DiaSources.
         """

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -48,6 +48,11 @@ class ApdbTest(ABC):
     fsrc_requires_id_list = False
     """Should be set to True if getDiaForcedSources requires object IDs"""
 
+    fsrc_history_region_filtering = False
+    """Should be set to True if forced sources history support region-based
+    filtering.
+    """
+
     # number of columns as defined in schema YAML files
     n_obj_columns = 91 + 2  # schema + schema-extra
     n_obj_last_columns = 17
@@ -222,37 +227,44 @@ class ApdbTest(ABC):
             DateTime("2021-01-01T00:03:00", DateTime.TAI),
             DateTime("2021-01-01T00:04:00", DateTime.TAI),
             DateTime("2021-01-01T00:05:00", DateTime.TAI),
-            DateTime("2021-01-01T00:06:00", DateTime.TAI)
+            DateTime("2021-01-01T00:06:00", DateTime.TAI),
+            DateTime("2021-03-01T00:01:00", DateTime.TAI),
+            DateTime("2021-03-01T00:02:00", DateTime.TAI),
         ]
-        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
+        end_time = DateTime("2021-03-02T00:00:00", DateTime.TAI)
 
         nobj = 100
         catalog1 = makeObjectCatalog(region1, nobj)
         apdb.store(visit_time[0], catalog1)
         apdb.store(visit_time[2], catalog1)
         apdb.store(visit_time[4], catalog1)
+        apdb.store(visit_time[6], catalog1)
         catalog2 = makeObjectCatalog(region2, nobj, start_id=nobj*2)
         apdb.store(visit_time[1], catalog2)
         apdb.store(visit_time[3], catalog2)
         apdb.store(visit_time[5], catalog2)
+        apdb.store(visit_time[7], catalog2)
 
         # read it back and check sizes
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 5, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 7, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 4, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 6, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 2, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 4, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
+        self.assert_catalog(res, nobj * 2, ApdbTables.DiaObject)
+
+        res = apdb.getDiaObjectsHistory(DateTime("2021-03-01T00:02:00.001", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(
@@ -276,12 +288,12 @@ class ApdbTest(ABC):
         res = apdb.getDiaObjectsHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
         )
-        self.assert_catalog(res, nobj * 3, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 4, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(
             DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
         )
-        self.assert_catalog(res, nobj * 2, ApdbTables.DiaObject)
+        self.assert_catalog(res, nobj * 3, ApdbTables.DiaObject)
 
         res = apdb.getDiaObjectsHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI),
@@ -340,8 +352,10 @@ class ApdbTest(ABC):
             (DateTime("2021-01-01T00:04:00", DateTime.TAI), objects2),
             (DateTime("2021-01-01T00:05:00", DateTime.TAI), objects1),
             (DateTime("2021-01-01T00:06:00", DateTime.TAI), objects2),
+            (DateTime("2021-03-01T00:01:00", DateTime.TAI), objects1),
+            (DateTime("2021-03-01T00:02:00", DateTime.TAI), objects2),
         ]
-        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
+        end_time = DateTime("2021-03-02T00:00:00", DateTime.TAI)
 
         start_id = 0
         for visit_time, objects in visits:
@@ -351,21 +365,24 @@ class ApdbTest(ABC):
 
         # read it back and check sizes
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 5, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 7, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 4, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 6, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 2, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 4, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
+        self.assert_catalog(res, nobj * 2, ApdbTables.DiaSource)
+
+        res = apdb.getDiaSourcesHistory(DateTime("2021-03-01T00:02:00.001", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(
@@ -389,12 +406,12 @@ class ApdbTest(ABC):
         res = apdb.getDiaSourcesHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
         )
-        self.assert_catalog(res, nobj * 3, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 4, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(
             DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
         )
-        self.assert_catalog(res, nobj * 2, ApdbTables.DiaSource)
+        self.assert_catalog(res, nobj * 3, ApdbTables.DiaSource)
 
         res = apdb.getDiaSourcesHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI),
@@ -449,8 +466,10 @@ class ApdbTest(ABC):
             (DateTime("2021-01-01T00:04:00", DateTime.TAI), objects2),
             (DateTime("2021-01-01T00:05:00", DateTime.TAI), objects1),
             (DateTime("2021-01-01T00:06:00", DateTime.TAI), objects2),
+            (DateTime("2021-03-01T00:01:00", DateTime.TAI), objects1),
+            (DateTime("2021-03-01T00:02:00", DateTime.TAI), objects2),
         ]
-        end_time = DateTime("2021-01-02T00:00:00", DateTime.TAI)
+        end_time = DateTime("2021-03-02T00:00:00", DateTime.TAI)
 
         start_id = 0
         for visit_time, objects in visits:
@@ -460,21 +479,24 @@ class ApdbTest(ABC):
 
         # read it back and check sizes
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
+        self.assert_catalog(res, nobj * 8, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:01:01", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 5, ApdbTables.DiaForcedSource)
+        self.assert_catalog(res, nobj * 7, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:02:30", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 4, ApdbTables.DiaForcedSource)
+        self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:05:00", DateTime.TAI), end_time)
-        self.assert_catalog(res, nobj * 2, ApdbTables.DiaForcedSource)
+        self.assert_catalog(res, nobj * 4, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(DateTime("2021-01-01T00:06:30", DateTime.TAI), end_time)
+        self.assert_catalog(res, nobj * 2, ApdbTables.DiaForcedSource)
+
+        res = apdb.getDiaForcedSourcesHistory(DateTime("2021-03-01T00:02:00.001", DateTime.TAI), end_time)
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(
@@ -498,19 +520,22 @@ class ApdbTest(ABC):
         res = apdb.getDiaForcedSourcesHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI), end_time, region=region1
         )
-        self.assert_catalog(res, nobj * 6, ApdbTables.DiaForcedSource)
+        rows = nobj * 4 if self.fsrc_history_region_filtering else nobj * 8
+        self.assert_catalog(res, rows, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(
             DateTime("2021-01-01T00:03:00", DateTime.TAI), end_time, region=region2
         )
-        self.assert_catalog(res, nobj * 4, ApdbTables.DiaForcedSource)
+        rows = nobj * 3 if self.fsrc_history_region_filtering else nobj * 6
+        self.assert_catalog(res, rows, ApdbTables.DiaForcedSource)
 
         res = apdb.getDiaForcedSourcesHistory(
             DateTime("2021-01-01T00:00:00", DateTime.TAI),
             DateTime("2021-01-01T00:03:30", DateTime.TAI),
             region1,
         )
-        self.assert_catalog(res, nobj * 3, ApdbTables.DiaForcedSource)
+        rows = nobj * 2 if self.fsrc_history_region_filtering else nobj * 3
+        self.assert_catalog(res, rows, ApdbTables.DiaForcedSource)
 
     def test_storeSSObjects(self) -> None:
         """Store and retrieve SSObjects."""

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -191,8 +191,8 @@ def makeSSObjectCatalog(count: int, start_id: int = 1, flags: int = 0) -> pandas
     """
     ids = numpy.arange(start_id, count + start_id, dtype=numpy.int64)
     arc = numpy.full(count, 0.001, dtype=numpy.float32)
-    flags = numpy.full(count, flags, dtype=numpy.int64)
+    flags_array = numpy.full(count, flags, dtype=numpy.int64)
     df = pandas.DataFrame({"ssObjectId": ids,
                            "arc": arc,
-                           "flags": flags})
+                           "flags": flags_array})
     return df

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -56,6 +56,7 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
     time_partition_tables = False
     time_partition_start = None
     time_partition_end = None
+    fsrc_history_region_filtering = True
 
     @classmethod
     def setUpClass(cls):

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -111,6 +111,7 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
         """Return number of columns for a specified table."""
 
         # Tables add one or two partitioning columns depending on config
+        n_part_columns = 0
         if table is ApdbTables.DiaObjectLast:
             n_part_columns = 1
         else:
@@ -127,6 +128,8 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
             return self.n_src_columns + n_part_columns
         elif table is ApdbTables.DiaForcedSource:
             return self.n_fsrc_columns + n_part_columns
+        elif table is ApdbTables.SSObject:
+            return self.n_ssobj_columns
 
     def getDiaObjects_table(self) -> ApdbTables:
         """Return type of table returned from getDiaObjects method."""


### PR DESCRIPTION
APDB API added few methods to support replication to/from PPDB on a previous ticket. This update adds an implementation of these new methods to Cassandra backend. Cassandra code was updated to use execution profiles, as the previous model gets deprecated. Also a continuing refactoring of Cassandra implementation in a couple of commits. It makes sense to look at the final diff, some pieces were changed more than once.