### PR TITLE
DM-36497: Add support for specifying schema name for tables

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ ignore_missing_imports = True
 [mypy-cassandra.*]
 ignore_missing_imports = True
 
-[mypy-cbor.*]
+[mypy-pandas.*]
 ignore_missing_imports = True
 
 [mypy-lsst.*]

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -174,7 +174,9 @@ class ApdbSqlConfig(ApdbConfig):
         dtype=str,
         doc=(
             "Namespace or schema name for all tables in APDB database. "
-            "Namespace/schema must already exist before APDB tables are created."
+            "Presently only makes sense for PostgresQL backend. "
+            "If schema with this name does not exist it will be created when "
+            "APDB tables are created."
         ),
         default=None,
         optional=True

--- a/python/lsst/dax/apdb/apdbSqlSchema.py
+++ b/python/lsst/dax/apdb/apdbSqlSchema.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 __all__ = ["ApdbSqlSchema"]
 
 import logging
-from typing import Any, Dict, List, Mapping, Type
+from typing import Any, Dict, List, Mapping, Optional, Type
 
 import sqlalchemy
 from sqlalchemy import (Column, Index, MetaData, PrimaryKeyConstraint,
@@ -68,9 +68,19 @@ class ApdbSqlSchema(ApdbSchema):
         Name of the schema in YAML files.
     prefix : `str`, optional
         Prefix to add to all scheam elements.
+    namespace : `str`, optional
+        Namespace (or schema name) to use for all APDB tables.
     """
-    def __init__(self, engine: sqlalchemy.engine.Engine, dia_object_index: str, htm_index_column: str,
-                 schema_file: str, schema_name: str = "ApdbSchema", prefix: str = ""):
+    def __init__(
+        self,
+        engine: sqlalchemy.engine.Engine,
+        dia_object_index: str,
+        htm_index_column: str,
+        schema_file: str,
+        schema_name: str = "ApdbSchema",
+        prefix: str = "",
+        namespace: Optional[str] = None,
+    ):
 
         super().__init__(schema_file, schema_name)
 
@@ -78,7 +88,7 @@ class ApdbSqlSchema(ApdbSchema):
         self._dia_object_index = dia_object_index
         self._prefix = prefix
 
-        self._metadata = MetaData(self._engine)
+        self._metadata = MetaData(self._engine, schema=namespace)
 
         # map YAML column types to SQLAlchemy
         self._type_map = dict(double=self._getDoubleType(engine),

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -27,7 +27,6 @@ import os
 import unittest
 from typing import Any
 
-import sqlalchemy
 from lsst.dax.apdb import ApdbConfig, ApdbSqlConfig, ApdbTables
 from lsst.dax.apdb.tests import ApdbTest
 import lsst.utils.tests
@@ -147,14 +146,8 @@ class ApdbPostgresTestCase(unittest.TestCase, ApdbSqlTest):
 class ApdbPostgresNamespaceTestCase(ApdbPostgresTestCase):
     """A test case for ApdbSql class using Postgres backend with schema name"""
 
-    namespace = "apdb_schema"
-
-    def setUp(self):
-        super().setUp()
-        # create namespace
-        engine = sqlalchemy.create_engine(self.server.url())
-        with engine.connect() as connection:
-            connection.execute(sqlalchemy.schema.CreateSchema(self.namespace))
+    # use mixed case to trigger quoting
+    namespace = "ApdbSchema"
 
     def make_config(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""


### PR DESCRIPTION
Adds a configuration field to ApdbSqlConfig which can specify alternative schema name to use for all tables. Schema needs to be created in advance, by default the default schema is used. Also adds a separate unit test case for Postgres (only runs if testing.postgres exists), which tests non-default schema name.