### PR TITLE
DM-36923: Re-design methods for export of APDB data.

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,0 +1,11 @@
+name: Check Python formatting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  call-workflow:
+    uses: lsst/rubin_workflows/.github/workflows/formatting.yaml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+        args:
+          - "--unsafe"
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3.10
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8

--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -20,4 +20,5 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import pkgutil
+
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/dax/__init__.py
+++ b/python/lsst/dax/__init__.py
@@ -20,4 +20,5 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import pkgutil
+
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -40,37 +40,28 @@ from .apdbSchema import ApdbTables
 
 
 def _data_file_name(basename: str) -> str:
-    """Return path name of a data file in sdm_schemas package.
-    """
+    """Return path name of a data file in sdm_schemas package."""
     return os.path.join("${SDM_SCHEMAS_DIR}", "yml", basename)
 
 
 class ApdbConfig(Config):
-    """Part of Apdb configuration common to all implementations.
-    """
-    read_sources_months = Field[int](
-        doc="Number of months of history to read from DiaSource",
-        default=12
-    )
+    """Part of Apdb configuration common to all implementations."""
+
+    read_sources_months = Field[int](doc="Number of months of history to read from DiaSource", default=12)
     read_forced_sources_months = Field[int](
-        doc="Number of months of history to read from DiaForcedSource",
-        default=12
+        doc="Number of months of history to read from DiaForcedSource", default=12
     )
     schema_file = Field[str](
-        doc="Location of (YAML) configuration file with standard schema",
-        default=_data_file_name("apdb.yaml")
+        doc="Location of (YAML) configuration file with standard schema", default=_data_file_name("apdb.yaml")
     )
-    schema_name = Field[str](
-        doc="Name of the schema in YAML configuration file.",
-        default="ApdbSchema"
-    )
+    schema_name = Field[str](doc="Name of the schema in YAML configuration file.", default="ApdbSchema")
     extra_schema_file = Field[str](
         doc="Location of (YAML) configuration file with extra schema, "
-            "definitions in this file are merged with the definitions in "
-            "'schema_file', extending or replacing parts of the schema.",
+        "definitions in this file are merged with the definitions in "
+        "'schema_file', extending or replacing parts of the schema.",
         default=None,
         optional=True,
-        deprecated="This field is deprecated, its value is not used."
+        deprecated="This field is deprecated, its value is not used.",
     )
     use_insert_id = Field[bool](
         doc=(
@@ -126,8 +117,7 @@ class ApdbInsertId:
 
 
 class Apdb(ABC):
-    """Abstract interface for APDB.
-    """
+    """Abstract interface for APDB."""
 
     ConfigClass = ApdbConfig
 
@@ -182,9 +172,9 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def getDiaSources(self, region: Region,
-                      object_ids: Optional[Iterable[int]],
-                      visit_time: dafBase.DateTime) -> Optional[pandas.DataFrame]:
+    def getDiaSources(
+        self, region: Region, object_ids: Optional[Iterable[int]], visit_time: dafBase.DateTime
+    ) -> Optional[pandas.DataFrame]:
         """Return catalog of DiaSource instances from a given region.
 
         Parameters
@@ -218,9 +208,9 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def getDiaForcedSources(self, region: Region,
-                            object_ids: Optional[Iterable[int]],
-                            visit_time: dafBase.DateTime) -> Optional[pandas.DataFrame]:
+    def getDiaForcedSources(
+        self, region: Region, object_ids: Optional[Iterable[int]], visit_time: dafBase.DateTime
+    ) -> Optional[pandas.DataFrame]:
         """Return catalog of DiaForcedSource instances from a given region.
 
         Parameters
@@ -371,11 +361,13 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def store(self,
-              visit_time: dafBase.DateTime,
-              objects: pandas.DataFrame,
-              sources: Optional[pandas.DataFrame] = None,
-              forced_sources: Optional[pandas.DataFrame] = None) -> None:
+    def store(
+        self,
+        visit_time: dafBase.DateTime,
+        objects: pandas.DataFrame,
+        sources: Optional[pandas.DataFrame] = None,
+        forced_sources: Optional[pandas.DataFrame] = None,
+    ) -> None:
         """Store all three types of catalogs in the database.
 
         Parameters

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["ApdbConfig", "Apdb"]
+__all__ = ["ApdbConfig", "Apdb", "ApdbTableData"]
 
 import os
 from abc import ABC, abstractmethod
@@ -69,6 +69,32 @@ class ApdbConfig(Config):
         optional=True,
         deprecated="This field is deprecated, its value is not used."
     )
+
+
+class ApdbTableData(ABC):
+    """Abstract class for representing table data."""
+
+    @abstractmethod
+    def column_names(self) -> list[str]:
+        """Return ordered sequence of column names in the table.
+
+        Returns
+        -------
+        names : `list` [`str`]
+            Column names.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def rows(self) -> Iterable[tuple]:
+        """Return table rows, each row is a tuple of values.
+
+        Returns
+        -------
+        rows : `iterable` [`tuple`]
+            Iterable of tuples.
+        """
+        raise NotImplementedError()
 
 
 class Apdb(ABC):
@@ -208,7 +234,7 @@ class Apdb(ABC):
     def getDiaObjectsHistory(self,
                              start_time: dafBase.DateTime,
                              end_time: dafBase.DateTime,
-                             region: Optional[Region] = None) -> pandas.DataFrame:
+                             region: Optional[Region] = None) -> ApdbTableData:
         """Returns catalog of DiaObject instances from a given time period
         including the history of each DiaObject.
 
@@ -227,7 +253,7 @@ class Apdb(ABC):
 
         Returns
         -------
-        catalog : `pandas.DataFrame`
+        data : `ApdbTableData`
             Catalog containing DiaObject records.
 
         Notes
@@ -241,7 +267,7 @@ class Apdb(ABC):
     def getDiaSourcesHistory(self,
                              start_time: dafBase.DateTime,
                              end_time: dafBase.DateTime,
-                             region: Optional[Region] = None) -> pandas.DataFrame:
+                             region: Optional[Region] = None) -> ApdbTableData:
         """Returns catalog of DiaSource instances from a given time period.
 
         Parameters
@@ -259,8 +285,8 @@ class Apdb(ABC):
 
         Returns
         -------
-        catalog : `pandas.DataFrame`
-            Catalog containing DiaObject records.
+        data : `ApdbTableData`
+            Catalog containing DiaSource records.
 
         Notes
         -----
@@ -273,7 +299,7 @@ class Apdb(ABC):
     def getDiaForcedSourcesHistory(self,
                                    start_time: dafBase.DateTime,
                                    end_time: dafBase.DateTime,
-                                   region: Optional[Region] = None) -> pandas.DataFrame:
+                                   region: Optional[Region] = None) -> ApdbTableData:
         """Returns catalog of DiaForcedSource instances from a given time
         period.
 
@@ -292,8 +318,8 @@ class Apdb(ABC):
 
         Returns
         -------
-        catalog : `pandas.DataFrame`
-            Catalog containing DiaObject records.
+        data : `ApdbTableData`
+            Catalog containing DiaForcedSource records.
 
         Notes
         -----

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -92,7 +92,7 @@ class ApdbCassandraConfig(ApdbConfig):
         default=cassandra.ProtocolVersion.V4 if CASSANDRA_IMPORTED else 0,
     )
     dia_object_columns = ListField[str](
-        doc="List of columns to read from DiaObject, by default read all columns", default=[]
+        doc="List of columns to read from DiaObject[Last], by default read all columns", default=[]
     )
     prefix = Field[str](doc="Prefix to add to table names", default="")
     part_pixelization = ChoiceField[str](

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -262,7 +262,7 @@ class ApdbCassandraSchema(ApdbSchema):
                 constraints=[],
                 annotations={
                     "cassandra:partitioning_columns": ["insert_id"],
-                    "cassandra:apdb_column_names": [column.name for column in apdb_table_def.columns]
+                    "cassandra:apdb_column_names": [column.name for column in apdb_table_def.columns],
                 },
             )
 

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -125,11 +125,6 @@ class ApdbSqlConfig(ApdbConfig):
     dia_object_columns = ListField[str](
         doc="List of columns to read from DiaObject, by default read all columns", default=[]
     )
-    object_last_replace = Field[bool](
-        doc='If True (default) then use "upsert" for DiaObjectsLast table',
-        default=True,
-        deprecated="This field is not used and will be removed on 2022-12-31.",
-    )
     prefix = Field[str](doc="Prefix to add to table names and index names", default="")
     namespace = Field[str](
         doc=(
@@ -141,7 +136,6 @@ class ApdbSqlConfig(ApdbConfig):
         default=None,
         optional=True,
     )
-    explain = Field[bool](doc="If True then run EXPLAIN SQL command on each executed query", default=False)
     timer = Field[bool](doc="If True then print/log timing information", default=False)
 
     def validate(self) -> None:

--- a/python/lsst/dax/apdb/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra_utils.py
@@ -35,6 +35,7 @@ import pandas
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from typing import Any
+from uuid import UUID
 
 # If cassandra-driver is not there the module can still be imported
 # but things will not work.
@@ -265,7 +266,7 @@ def literal(v: Any) -> Any:
         pass
     elif isinstance(v, datetime):
         v = int((v - datetime(1970, 1, 1)) / timedelta(seconds=1)) * 1000
-    elif isinstance(v, (bytes, str)):
+    elif isinstance(v, (bytes, str, UUID, int)):
         pass
     else:
         try:

--- a/python/lsst/dax/apdb/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra_utils.py
@@ -30,12 +30,13 @@ __all__ = [
 ]
 
 import logging
-import numpy as np
-import pandas
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
+
+import numpy as np
+import pandas
 
 # If cassandra-driver is not there the module can still be imported
 # but things will not work.
@@ -48,7 +49,6 @@ except ImportError:
     CASSANDRA_IMPORTED = False
 
 from .apdb import ApdbTableData
-
 
 _LOG = logging.getLogger(__name__)
 
@@ -66,9 +66,7 @@ if CASSANDRA_IMPORTED:
         wrapper can be dropped.
         """
 
-        def __init__(
-            self, session: Session, execution_profile: Any = EXEC_PROFILE_DEFAULT
-        ):
+        def __init__(self, session: Session, execution_profile: Any = EXEC_PROFILE_DEFAULT):
             self._session = session
             self._execution_profile = execution_profile
 
@@ -81,9 +79,7 @@ if CASSANDRA_IMPORTED:
             # explicit parameter can override our settings
             if execution_profile is EXEC_PROFILE_DEFAULT:
                 execution_profile = self._execution_profile
-            return self._session.execute_async(
-                *args, execution_profile=execution_profile, **kwargs
-            )
+            return self._session.execute_async(*args, execution_profile=execution_profile, **kwargs)
 
         def submit(self, *args: Any, **kwargs: Any) -> Any:
             # internal method
@@ -108,9 +104,7 @@ class ApdbCassandraTableData(ApdbTableData):
     def append(self, other: ApdbCassandraTableData) -> None:
         """Extend rows in this table with rows in other table"""
         if self._columns != other._columns:
-            raise ValueError(
-                f"Different columns returned by queries: {self._columns} and {other._columns}"
-            )
+            raise ValueError(f"Different columns returned by queries: {self._columns} and {other._columns}")
         self._rows.extend(other._rows)
 
     def __iter__(self) -> Iterator[tuple]:

--- a/python/lsst/dax/apdb/pixelization.py
+++ b/python/lsst/dax/apdb/pixelization.py
@@ -28,7 +28,6 @@ from typing import List, Tuple
 
 from lsst import sphgeom
 
-
 _LOG = logging.getLogger(__name__)
 
 

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -181,8 +181,7 @@ class ApdbTest(ABC):
         """
 
         # set read_sources_months to 0 so that Forced/Sources are None
-        config = self.make_config(read_sources_months=0,
-                                  read_forced_sources_months=0)
+        config = self.make_config(read_sources_months=0, read_forced_sources_months=0)
         apdb = make_apdb(config)
         apdb.makeSchema()
 
@@ -403,12 +402,16 @@ class ApdbTest(ABC):
         self.assert_catalog(res, len(sources) - 3, ApdbTables.DiaSource)
 
         with self.assertRaisesRegex(ValueError, r"do not exist.*\D1000"):
-            apdb.reassignDiaSources({1000: 1, 7: 3, })
+            apdb.reassignDiaSources(
+                {
+                    1000: 1,
+                    7: 3,
+                }
+            )
         self.assert_catalog(res, len(sources) - 3, ApdbTables.DiaSource)
 
     def test_midPointTai_src(self) -> None:
-        """Test for time filtering of DiaSources.
-        """
+        """Test for time filtering of DiaSources."""
         config = self.make_config()
         apdb = make_apdb(config)
         apdb.makeSchema()
@@ -446,8 +449,7 @@ class ApdbTest(ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaSource)
 
     def test_midPointTai_fsrc(self) -> None:
-        """Test for time filtering of DiaForcedSources.
-        """
+        """Test for time filtering of DiaForcedSources."""
         config = self.make_config()
         apdb = make_apdb(config)
         apdb.makeSchema()

--- a/python/lsst/dax/apdb/timer.py
+++ b/python/lsst/dax/apdb/timer.py
@@ -32,7 +32,6 @@ import resource
 import time
 from typing import Any, Optional, Type
 
-
 _LOG = logging.getLogger(__name__)
 
 
@@ -50,6 +49,7 @@ class Timer:
             engine.execute('SELECT ...')
 
     """
+
     def __init__(self, name: str = "", doPrint: bool = True):
         """
         Parameters
@@ -62,12 +62,12 @@ class Timer:
         self._name = name
         self._print = doPrint
 
-        self._startReal = -1.
-        self._startUser = -1.
-        self._startSys = -1.
-        self._sumReal = 0.
-        self._sumUser = 0.
-        self._sumSys = 0.
+        self._startReal = -1.0
+        self._startUser = -1.0
+        self._startSys = -1.0
+        self._sumReal = 0.0
+        self._sumUser = 0.0
+        self._sumSys = 0.0
 
     def start(self) -> Timer:
         """
@@ -88,9 +88,9 @@ class Timer:
             ru = resource.getrusage(resource.RUSAGE_SELF)
             self._sumUser += ru.ru_utime - self._startUser
             self._sumSys += ru.ru_stime - self._startSys
-            self._startReal = -1.
-            self._startUser = -1.
-            self._startSys = -1.
+            self._startReal = -1.0
+            self._startUser = -1.0
+            self._startSys = -1.0
         return self
 
     def dump(self) -> Timer:

--- a/tests/test_ap_verify_queries.py
+++ b/tests/test_ap_verify_queries.py
@@ -19,15 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import numpy
 import os
-import pandas
 import unittest.mock
-import lsst.utils.tests
 from collections.abc import Mapping
 from typing import Any
 
 import lsst.geom as geom
+import lsst.utils.tests
+import numpy
+import pandas
 from lsst.daf.base import DateTime
 from lsst.dax.apdb import ApdbSql, ApdbSqlConfig
 
@@ -65,11 +65,10 @@ def createTestObjects(
 
 
 class TestApVerifyQueries(unittest.TestCase):
-
     def setUp(self) -> None:
         self.apdbCfg = ApdbSqlConfig()
         # Create DB in memory.
-        self.apdbCfg.db_url = 'sqlite://'
+        self.apdbCfg.db_url = "sqlite://"
         self.apdbCfg.schema_file = TEST_SCHEMA
         self.apdbCfg.dia_object_index = "baseline"
         self.apdbCfg.dia_object_columns = []
@@ -85,7 +84,7 @@ class TestApVerifyQueries(unittest.TestCase):
 
     def test_count_objects(self) -> None:
         n_created = 5
-        objects = createTestObjects(n_created, "diaObjectId", {'nDiaSources': int})
+        objects = createTestObjects(n_created, "diaObjectId", {"nDiaSources": int})
         objects.at[n_created - 1, "nDiaSources"] = 2
 
         # nsecs must be an integer, not 1.4e18

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -40,10 +40,10 @@ import unittest
 import uuid
 from typing import TYPE_CHECKING, Any, Optional
 
+import lsst.utils.tests
 from lsst.dax.apdb import ApdbCassandra, ApdbCassandraConfig, ApdbTables
 from lsst.dax.apdb.apdbCassandra import CASSANDRA_IMPORTED
 from lsst.dax.apdb.tests import ApdbSchemaUpdateTest, ApdbTest
-import lsst.utils.tests
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
 
@@ -55,8 +55,7 @@ class ApdbCassandraMixin:
 
     @classmethod
     def setUpClass(cls) -> None:
-        """Prepare config for server connection.
-        """
+        """Prepare config for server connection."""
         cluster_host = os.environ.get("DAX_APDB_TEST_CASSANDRA_CLUSTER")
         if not cluster_host:
             raise unittest.SkipTest("DAX_APDB_TEST_CASSANDRA_CLUSTER is not set")
@@ -64,8 +63,7 @@ class ApdbCassandraMixin:
             raise unittest.SkipTest("cassandra_driver cannot be imported")
 
     def setUp(self) -> None:
-        """Prepare config for server connection.
-        """
+        """Prepare config for server connection."""
         self.cluster_host = os.environ.get("DAX_APDB_TEST_CASSANDRA_CLUSTER")
         self.keyspace = ""
 

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -38,11 +38,11 @@ import logging
 import os
 import unittest
 import uuid
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from lsst.dax.apdb import ApdbCassandra, ApdbCassandraConfig, ApdbTables
 from lsst.dax.apdb.apdbCassandra import CASSANDRA_IMPORTED
-from lsst.dax.apdb.tests import ApdbTest
+from lsst.dax.apdb.tests import ApdbSchemaUpdateTest, ApdbTest
 import lsst.utils.tests
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
@@ -50,14 +50,8 @@ TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/s
 logging.basicConfig(level=logging.INFO)
 
 
-class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
-    """A test case for ApdbCassandra class
-    """
-
-    time_partition_tables = False
-    time_partition_start: Optional[str] = None
-    time_partition_end: Optional[str] = None
-    fsrc_history_region_filtering = True
+class ApdbCassandraMixin:
+    """Mixin class which defines common methods for unit tests."""
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -80,8 +74,10 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
         # create dedicated keyspace for each test
         key = uuid.uuid4()
         self.keyspace = f"apdb_{key.hex}"
-        query = f"CREATE KEYSPACE {self.keyspace}" \
+        query = (
+            f"CREATE KEYSPACE {self.keyspace}"
             " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"
+        )
 
         apdb = ApdbCassandra(config)
         apdb._session.execute(query)
@@ -95,6 +91,19 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
         apdb._session.execute(query)
         del apdb
 
+    if TYPE_CHECKING:
+        # For mypy.
+        def make_config(self, **kwargs: Any) -> ApdbCassandraConfig:
+            ...
+
+
+class ApdbCassandraTestCase(ApdbCassandraMixin, unittest.TestCase, ApdbTest):
+    """A test case for ApdbCassandra class"""
+
+    time_partition_tables = False
+    time_partition_start: Optional[str] = None
+    time_partition_end: Optional[str] = None
+
     def make_config(self, **kwargs: Any) -> ApdbCassandraConfig:
         """Make config class instance used in all tests."""
         kw = {
@@ -102,6 +111,7 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
             "keyspace": self.keyspace,
             "schema_file": TEST_SCHEMA,
             "time_partition_tables": self.time_partition_tables,
+            "use_insert_id": self.use_insert_id,
         }
         if self.time_partition_start:
             kw["time_partition_start"] = self.time_partition_start
@@ -110,43 +120,38 @@ class ApdbCassandraTestCase(unittest.TestCase, ApdbTest):
         kw.update(kwargs)
         return ApdbCassandraConfig(**kw)
 
-    def n_columns(self, table: ApdbTables) -> int:
-        """Return number of columns for a specified table."""
-
-        # Tables add one or two partitioning columns depending on config
-        n_part_columns = 0
-        if table is ApdbTables.DiaObjectLast:
-            n_part_columns = 1
-        else:
-            if self.time_partition_tables:
-                n_part_columns = 1
-            else:
-                n_part_columns = 2
-
-        if table is ApdbTables.DiaObject:
-            return self.n_obj_columns + n_part_columns
-        elif table is ApdbTables.DiaObjectLast:
-            return self.n_obj_last_columns + n_part_columns
-        elif table is ApdbTables.DiaSource:
-            return self.n_src_columns + n_part_columns
-        elif table is ApdbTables.DiaForcedSource:
-            return self.n_fsrc_columns + n_part_columns
-        elif table is ApdbTables.SSObject:
-            return self.n_ssobj_columns
-        return -1
-
     def getDiaObjects_table(self) -> ApdbTables:
         """Return type of table returned from getDiaObjects method."""
         return ApdbTables.DiaObjectLast
 
 
 class ApdbCassandraPerMonthTestCase(ApdbCassandraTestCase):
-    """A test case for ApdbCassandra class with per-month tables.
-    """
+    """A test case for ApdbCassandra class with per-month tables."""
 
     time_partition_tables = True
     time_partition_start = "2019-12-01T00:00:00"
     time_partition_end = "2022-01-01T00:00:00"
+
+
+class ApdbCassandraTestCaseInsertIds(ApdbCassandraTestCase):
+    """A test case  with use_insert_id."""
+
+    use_insert_id = True
+
+
+class ApdbSchemaUpdateCassandraTestCase(ApdbCassandraMixin, unittest.TestCase, ApdbSchemaUpdateTest):
+    """A test case for schema updates using Cassandra backend."""
+
+    def make_config(self, **kwargs: Any) -> ApdbCassandraConfig:
+        """Make config class instance used in all tests."""
+        kw = {
+            "contact_points": [self.cluster_host],
+            "keyspace": self.keyspace,
+            "schema_file": TEST_SCHEMA,
+            "time_partition_tables": False,
+        }
+        kw.update(kwargs)
+        return ApdbCassandraConfig(**kw)
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -29,9 +29,9 @@ import tempfile
 import unittest
 from typing import Any
 
+import lsst.utils.tests
 from lsst.dax.apdb import ApdbConfig, ApdbSqlConfig, ApdbTables
 from lsst.dax.apdb.tests import ApdbSchemaUpdateTest, ApdbTest
-import lsst.utils.tests
 
 try:
     import testing.postgresql
@@ -84,8 +84,7 @@ class ApdbSQLiteTestCasePixIdIovIndex(ApdbSQLiteTestCase):
 
 
 class ApdbSQLiteTestCaseInsertIds(ApdbSQLiteTestCase):
-    """A test case for ApdbSql class using SQLite backend with use_insert_id.
-    """
+    """A test case for ApdbSql class using SQLite backend with use_insert_id."""
 
     use_insert_id = True
 
@@ -124,7 +123,7 @@ class ApdbPostgresTestCase(unittest.TestCase, ApdbTest):
         kw = {
             "db_url": self.server.url(),
             "schema_file": TEST_SCHEMA,
-            "dia_object_index": self.dia_object_index
+            "dia_object_index": self.dia_object_index,
         }
         kw.update(kwargs)
         return ApdbSqlConfig(**kw)

--- a/tests/test_apdbSqlSchema.py
+++ b/tests/test_apdbSqlSchema.py
@@ -28,8 +28,8 @@ from typing import Any
 
 import lsst.utils.tests
 import sqlalchemy
-from lsst.dax.apdb.apdbSqlSchema import ApdbSqlSchema, ExtraTables
 from lsst.dax.apdb.apdbSchema import ApdbTables
+from lsst.dax.apdb.apdbSqlSchema import ApdbSqlSchema, ExtraTables
 from sqlalchemy import create_engine
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")

--- a/tests/test_apdbSqlSchema.py
+++ b/tests/test_apdbSqlSchema.py
@@ -28,19 +28,24 @@ from typing import Any
 
 import lsst.utils.tests
 import sqlalchemy
-from lsst.dax.apdb.apdbSqlSchema import ApdbSqlSchema
+from lsst.dax.apdb.apdbSqlSchema import ApdbSqlSchema, ExtraTables
+from lsst.dax.apdb.apdbSchema import ApdbTables
 from sqlalchemy import create_engine
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
 
 
 class ApdbSchemaTestCase(unittest.TestCase):
-    """A test case for ApdbSqlSchema class
-    """
+    """Test case for ApdbSqlSchema class."""
 
-    @classmethod
-    def setUpClass(cls) -> None:
-        pass
+    # number of columns as defined in tests/config/schema.yaml
+    table_column_count = {
+        ApdbTables.DiaObject: 8,
+        ApdbTables.DiaObjectLast: 5,
+        ApdbTables.DiaSource: 10,
+        ApdbTables.DiaForcedSource: 4,
+        ApdbTables.SSObject: 3,
+    }
 
     def _assertTable(self, table: sqlalchemy.schema.Table, name: str, ncol: int) -> None:
         """validation for tables schema.
@@ -63,58 +68,135 @@ class ApdbSchemaTestCase(unittest.TestCase):
         Schema is defined in YAML files, some checks here depend on that
         configuration and will need to be updated when configuration changes.
         """
-        engine = create_engine('sqlite://')
+        engine = create_engine("sqlite://")
 
         # create standard (baseline) schema
-        schema = ApdbSqlSchema(engine=engine,
-                               dia_object_index="baseline",
-                               htm_index_column="pixelId",
-                               schema_file=TEST_SCHEMA)
+        schema = ApdbSqlSchema(
+            engine=engine, dia_object_index="baseline", htm_index_column="pixelId", schema_file=TEST_SCHEMA
+        )
         schema.makeSchema()
-        self._assertTable(schema.objects, "DiaObject", 9)
-        self.assertEqual(len(schema.objects.primary_key), 2)
-        self.assertIsNone(schema.objects_last)
-        self._assertTable(schema.sources, "DiaSource", 11)
-        self._assertTable(schema.forcedSources, "DiaForcedSource", 4)
+        table = schema.get_table(ApdbTables.DiaObject)
+        # DiaObject table adds pixelId column.
+        self._assertTable(table, "DiaObject", self.table_column_count[ApdbTables.DiaObject] + 1)
+        self.assertEqual(len(table.primary_key), 2)
+        self.assertEqual(
+            len(schema.get_apdb_columns(ApdbTables.DiaObject)), self.table_column_count[ApdbTables.DiaObject]
+        )
+        with self.assertRaisesRegex(ValueError, ".*does not exist in the schema"):
+            schema.get_table(ApdbTables.DiaObjectLast)
+        # DiaSource table also adds pixelId column.
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaSource),
+            "DiaSource",
+            self.table_column_count[ApdbTables.DiaSource] + 1,
+        )
+        self.assertEqual(
+            len(schema.get_apdb_columns(ApdbTables.DiaSource)), self.table_column_count[ApdbTables.DiaSource]
+        )
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaForcedSource),
+            "DiaForcedSource",
+            self.table_column_count[ApdbTables.DiaForcedSource],
+        )
+        self.assertEqual(
+            len(schema.get_apdb_columns(ApdbTables.DiaForcedSource)),
+            self.table_column_count[ApdbTables.DiaForcedSource],
+        )
+        for table_enum in ExtraTables:
+            with self.assertRaisesRegex(ValueError, ".*does not exist in the schema"):
+                schema.get_table(table_enum)
 
         # create schema using prefix
-        schema = ApdbSqlSchema(engine=engine,
-                               dia_object_index="baseline",
-                               htm_index_column="pixelId",
-                               schema_file=TEST_SCHEMA,
-                               prefix="Pfx")
+        schema = ApdbSqlSchema(
+            engine=engine,
+            dia_object_index="baseline",
+            htm_index_column="pixelId",
+            schema_file=TEST_SCHEMA,
+            prefix="Pfx",
+        )
         # Drop existing tables (but we don't check it here)
         schema.makeSchema(drop=True)
-        self._assertTable(schema.objects, "PfxDiaObject", 9)
-        self.assertIsNone(schema.objects_last)
-        self._assertTable(schema.sources, "PfxDiaSource", 11)
-        self._assertTable(schema.forcedSources, "PfxDiaForcedSource", 4)
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaObject),
+            "PfxDiaObject",
+            self.table_column_count[ApdbTables.DiaObject] + 1,
+        )
+        with self.assertRaisesRegex(ValueError, ".*does not exist in the schema"):
+            schema.get_table(ApdbTables.DiaObjectLast)
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaSource),
+            "PfxDiaSource",
+            self.table_column_count[ApdbTables.DiaSource] + 1,
+        )
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaForcedSource),
+            "PfxDiaForcedSource",
+            self.table_column_count[ApdbTables.DiaForcedSource],
+        )
 
-        # use different indexing for DiaObject, need extra schema for that
-        schema = ApdbSqlSchema(engine=engine,
-                               dia_object_index="pix_id_iov",
-                               htm_index_column="pixelId",
-                               schema_file=TEST_SCHEMA)
+        # use different indexing for DiaObject, changes number of PK columns
+        schema = ApdbSqlSchema(
+            engine=engine, dia_object_index="pix_id_iov", htm_index_column="pixelId", schema_file=TEST_SCHEMA
+        )
         schema.makeSchema(drop=True)
-        self._assertTable(schema.objects, "DiaObject", 9)
-        self.assertEqual(len(schema.objects.primary_key), 3)
-        self.assertIsNone(schema.objects_last)
-        self._assertTable(schema.sources, "DiaSource", 11)
-        self._assertTable(schema.forcedSources, "DiaForcedSource", 4)
+        table = schema.get_table(ApdbTables.DiaObject)
+        self._assertTable(table, "DiaObject", self.table_column_count[ApdbTables.DiaObject] + 1)
+        self.assertEqual(len(table.primary_key), 3)
+        with self.assertRaisesRegex(ValueError, ".*does not exist in the schema"):
+            schema.get_table(ApdbTables.DiaObjectLast)
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaSource),
+            "DiaSource",
+            self.table_column_count[ApdbTables.DiaSource] + 1,
+        )
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaForcedSource),
+            "DiaForcedSource",
+            self.table_column_count[ApdbTables.DiaForcedSource],
+        )
 
         # use DiaObjectLast table for DiaObject
-        schema = ApdbSqlSchema(engine=engine,
-                               dia_object_index="last_object_table",
-                               htm_index_column="pixelId",
-                               schema_file=TEST_SCHEMA)
+        schema = ApdbSqlSchema(
+            engine=engine,
+            dia_object_index="last_object_table",
+            htm_index_column="pixelId",
+            schema_file=TEST_SCHEMA,
+        )
         schema.makeSchema(drop=True)
-        self._assertTable(schema.objects, "DiaObject", 9)
-        self.assertEqual(len(schema.objects.primary_key), 2)
-        self._assertTable(schema.objects_last, "DiaObjectLast", 6)
-        assert schema.objects_last is not None
-        self.assertEqual(len(schema.objects_last.primary_key), 2)
-        self._assertTable(schema.sources, "DiaSource", 11)
-        self._assertTable(schema.forcedSources, "DiaForcedSource", 4)
+        table = schema.get_table(ApdbTables.DiaObject)
+        self._assertTable(table, "DiaObject", self.table_column_count[ApdbTables.DiaObject] + 1)
+        self.assertEqual(len(table.primary_key), 2)
+        table = schema.get_table(ApdbTables.DiaObjectLast)
+        self._assertTable(table, "DiaObjectLast", self.table_column_count[ApdbTables.DiaObjectLast] + 1)
+        self.assertEqual(len(table.primary_key), 2)
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaSource),
+            "DiaSource",
+            self.table_column_count[ApdbTables.DiaSource] + 1,
+        )
+        self._assertTable(
+            schema.get_table(ApdbTables.DiaForcedSource),
+            "DiaForcedSource",
+            self.table_column_count[ApdbTables.DiaForcedSource],
+        )
+
+        # Add history_id tables
+        schema = ApdbSqlSchema(
+            engine=engine,
+            dia_object_index="last_object_table",
+            htm_index_column="pixelId",
+            schema_file=TEST_SCHEMA,
+            use_insert_id=True,
+        )
+        schema.makeSchema(drop=True)
+        self._assertTable(schema.get_table(ExtraTables.DiaInsertId), "DiaInsertId", 2)
+        self.assertEqual(len(schema.get_apdb_columns(ExtraTables.DiaInsertId)), 2)
+        self._assertTable(schema.get_table(ExtraTables.DiaObjectInsertId), "DiaObjectInsertId", 3)
+        self.assertEqual(len(schema.get_apdb_columns(ExtraTables.DiaObjectInsertId)), 3)
+        self._assertTable(schema.get_table(ExtraTables.DiaSourceInsertId), "DiaSourceInsertId", 2)
+        self.assertEqual(len(schema.get_apdb_columns(ExtraTables.DiaSourceInsertId)), 2)
+        self._assertTable(schema.get_table(ExtraTables.DiaForcedSourceInsertId), "DiaFSourceInsertId", 3)
+        self.assertEqual(len(schema.get_apdb_columns(ExtraTables.DiaForcedSourceInsertId)), 3)
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This changes APDB interface for accessing history, history is now defined
in terms of "insert ID" values, each call to `store()` method generates
new "insert ID" in the database. APD interface is extended to query the
list of known insert IDs and drop them. Get-history methods now accept
a list of insert IDs.

This commit also includes changes for both backends to limit the columns
returned from "get" method to those declared in the schema, dropping
extra partitioning/clustering columns. This also simplifies unit tests.