### PR TITLE
DM-37744: Make SQL implementation compatible with sqlalchemy 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -17,11 +17,11 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -72,7 +72,6 @@ class CassandraMissingError(Exception):
 
 
 class ApdbCassandraConfig(ApdbConfig):
-
     contact_points = ListField[str](
         doc="The list of contact points to try connecting for cluster discovery.", default=["127.0.0.1"]
     )
@@ -181,7 +180,6 @@ class ApdbCassandra(Apdb):
     """Start time for partition 0, this should never be changed."""
 
     def __init__(self, config: ApdbCassandraConfig):
-
         if not CASSANDRA_IMPORTED:
             raise CassandraMissingError()
 
@@ -653,7 +651,6 @@ class ApdbCassandra(Apdb):
         return table_data
 
     def _storeInsertId(self, insert_id: ApdbInsertId, visit_time: dafBase.DateTime) -> None:
-
         # Cassandra timestamp uses milliseconds since epoch
         timestamp = visit_time.nsecs() // 1_000_000
 
@@ -811,7 +808,6 @@ class ApdbCassandra(Apdb):
         qfields_str = ",".join(qfields)
 
         with Timer(table_name.name + " query build", self.config.timer):
-
             table = self._schema.tableName(table_name)
             if time_part is not None:
                 table = f"{table}_{time_part}"

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -132,7 +132,6 @@ class ApdbCassandraSchema(ApdbSchema):
         time_partition_tables: bool = False,
         use_insert_id: bool = False,
     ):
-
         super().__init__(schema_file, schema_name)
 
         self._session = session
@@ -250,7 +249,6 @@ class ApdbCassandraSchema(ApdbSchema):
         )
 
         for insert_id_table_enum, apdb_table_enum in ExtraTables.insert_id_tables().items():
-
             apdb_table_def = self.tableSchemas[apdb_table_enum]
 
             extra_tables[insert_id_table_enum] = simple.Table(

--- a/python/lsst/dax/apdb/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra_utils.py
@@ -202,7 +202,6 @@ def select_concurrent(
 
     ep = session.get_execution_profile(execution_profile)
     if ep.row_factory is raw_data_factory:
-
         # Collect rows into a single list and build Dataframe out of that
         _LOG.debug("making pandas data frame out of rows/columns")
         table_data: ApdbCassandraTableData | None = None
@@ -222,7 +221,6 @@ def select_concurrent(
         return table_data
 
     elif ep.row_factory is pandas_dataframe_factory:
-
         # Merge multiple DataFrames into one
         _LOG.debug("making pandas data frame out of set of data frames")
         dataframes = []
@@ -241,7 +239,6 @@ def select_concurrent(
         return catalog
 
     else:
-
         # Just concatenate all rows into a single collection.
         rows = []
         for success, result in results:

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -82,7 +82,6 @@ class ApdbCassandraMixin:
         del apdb
 
     def tearDown(self) -> None:
-
         config = self.make_config()
         apdb = ApdbCassandra(config)
         query = f"DROP KEYSPACE {self.keyspace}"


### PR DESCRIPTION
Major issue here was Pandas and our use of its to_sql method. Pandas is still not compatible with SA2 transaction handling. I added a terrible hack to woraround that, a Connection-like class which looks more like 1.4 Connection class and wraps actual Connection. All unit tests run successfully. Also lots of mypy fixes.