### PR TITLE
DM-40492: Change default value of use_insert_id

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -65,11 +65,11 @@ class ApdbConfig(Config):
     )
     use_insert_id = Field[bool](
         doc=(
-            "If True (default), make and fill additional tables used for getHistory methods. "
+            "If True, make and fill additional tables used for getHistory methods. "
             "Databases created with earlier versions of APDB may not have these tables, "
             "and corresponding methods will not work for them."
         ),
-        default=True,
+        default=False,
     )
 
 


### PR DESCRIPTION
Changing it to `False`, `True` is only useful for production service and just wastes resources during testing.