### PR TITLE
DM-41639: Allow Apdb queries for visit completion

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -253,6 +253,23 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def containsVisitDetector(self, visit: int, detector: int) -> bool:
+        """Test whether data for a given visit-detector is present in the APDB.
+
+        Parameters
+        ----------
+        visit, detector : `int`
+            The ID of the visit-detector to search for.
+
+        Returns
+        -------
+        present : `bool`
+            `True` if some DiaObject, DiaSource, or DiaForcedSource records
+            exist for the specified observation, `False` otherwise.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def getInsertIds(self) -> list[ApdbInsertId] | None:
         """Return collection of insert identifiers known to the database.
 

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -366,6 +366,10 @@ class ApdbCassandra(Apdb):
 
         return self._getSources(region, object_ids, mjd_start, mjd_end, ApdbTables.DiaForcedSource)
 
+    def containsVisitDetector(self, visit: int, detector: int) -> bool:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
     def getInsertIds(self) -> list[ApdbInsertId] | None:
         # docstring is inherited from a base class
         if not self._schema.has_insert_id:

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -387,6 +387,10 @@ class ApdbSql(Apdb):
         _LOG.debug("found %s DiaForcedSources", len(sources))
         return sources
 
+    def containsVisitDetector(self, visit: int, detector: int) -> bool:
+        # docstring is inherited from a base class
+        raise NotImplementedError()
+
     def getInsertIds(self) -> list[ApdbInsertId] | None:
         # docstring is inherited from a base class
         if not self._schema.has_insert_id:

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas
 from lsst.daf.base import DateTime
-from lsst.dax.apdb import ApdbConfig, ApdbInsertId, ApdbTableData, ApdbTables, make_apdb
+from lsst.dax.apdb import ApdbConfig, ApdbInsertId, ApdbSql, ApdbTableData, ApdbTables, make_apdb
 from lsst.sphgeom import Angle, Circle, Region, UnitVector3d
 
 from .data_factory import makeForcedSourceCatalog, makeObjectCatalog, makeSourceCatalog, makeSSObjectCatalog
@@ -186,6 +186,11 @@ class ApdbTest(TestCaseMixin, ABC):
             with self.assertRaises(NotImplementedError):
                 apdb.containsVisitDetector(visit=0, detector=0)
 
+        # alternative method not part of the Apdb API
+        if isinstance(apdb, ApdbSql):
+            res = apdb.containsCcdVisit(1)
+            self.assertFalse(res)
+
         # get sources by region
         if self.fsrc_requires_id_list:
             with self.assertRaises(NotImplementedError):
@@ -232,6 +237,11 @@ class ApdbTest(TestCaseMixin, ABC):
         else:
             with self.assertRaises(NotImplementedError):
                 apdb.containsVisitDetector(visit=0, detector=0)
+
+        # alternative method not part of the Apdb API
+        if isinstance(apdb, ApdbSql):
+            res = apdb.containsCcdVisit(1)
+            self.assertFalse(res)
 
     def test_storeObjects(self) -> None:
         """Store and retrieve DiaObjects."""
@@ -293,6 +303,13 @@ class ApdbTest(TestCaseMixin, ABC):
             with self.assertRaises(NotImplementedError):
                 apdb.containsVisitDetector(visit=0, detector=0)
 
+        # alternative method not part of the Apdb API
+        if isinstance(apdb, ApdbSql):
+            res = apdb.containsCcdVisit(1)
+            self.assertTrue(res)
+            res = apdb.containsCcdVisit(42)
+            self.assertFalse(res)
+
     def test_storeForcedSources(self) -> None:
         """Store and retrieve DiaForcedSources."""
         config = self.make_config()
@@ -318,6 +335,13 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         # TODO: test apdb.contains with generic implementation from DM-41671
+
+        # alternative method not part of the Apdb API
+        if isinstance(apdb, ApdbSql):
+            res = apdb.containsCcdVisit(1)
+            self.assertTrue(res)
+            res = apdb.containsCcdVisit(42)
+            self.assertFalse(res)
 
     def test_getHistory(self) -> None:
         """Store and retrieve catalog history."""

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -97,6 +97,7 @@ class ApdbCassandraMixin:
 class ApdbCassandraTestCase(ApdbCassandraMixin, unittest.TestCase, ApdbTest):
     """A test case for ApdbCassandra class"""
 
+    allow_visit_query = False
     time_partition_tables = False
     time_partition_start: str | None = None
     time_partition_end: str | None = None

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -46,6 +46,7 @@ class ApdbSQLiteTestCase(unittest.TestCase, ApdbTest):
 
     fsrc_requires_id_list = True
     dia_object_index = "baseline"
+    allow_visit_query = False
 
     def make_config(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
@@ -97,6 +98,7 @@ class ApdbPostgresTestCase(unittest.TestCase, ApdbTest):
     dia_object_index = "last_object_table"
     postgresql: Any
     use_insert_id = True
+    allow_visit_query = False
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
This PR adds two methods for querying the presence of a visit-detector on an APDB. The first, `Apdb.contains`, is the preferred long-term solution, but cannot be implemented without schema changes. The second, `ApdbSql.containsCcdVisit`, can work right away but requires arguments that are not compatible with `contains` (and cannot be _efficiently_ implemented in Cassandra).

The Jira issue(s) that would allow `containsCcdVisit` to be retired in favor of `contains` should be defined before this PR is merged.