### PR TITLE
DM-41028: Add schema version support and check to SQL backend

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,3 +9,8 @@ on:
 jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
+    rev: 23.12.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -17,12 +17,12 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.289
+    rev: v0.1.14
     hooks:
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,28 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         args:
           - "--unsafe"
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.11.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.289
     hooks:
-      - id: flake8
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ zip-safe = true
 license-files = ["COPYRIGHT", "LICENSE"]
 
 [tool.setuptools.package-data]
-"lsst.dax.apdb" = []
+"lsst.dax.apdb" = ["py.typed"]
 
 [tool.setuptools.dynamic]
 version = { attr = "lsst_versions.get_lsst_version" }
@@ -70,41 +70,41 @@ write_to = "python/lsst/dax/apdb/version.py"
 
 [tool.ruff]
 exclude = [
-"__init__.py",
-"config/apdb-cassandra.py",
-"config/apdb-mysql.py",
-"config/apdb-pg.py",
-"config/apdb-sqlite.py",
-"doc/conf.py",
+    "__init__.py",
+    "config/apdb-cassandra.py",
+    "config/apdb-mysql.py",
+    "config/apdb-pg.py",
+    "config/apdb-sqlite.py",
+    "doc/conf.py",
 ]
 ignore = [
-"N802",
-"N803",
-"N806",
-"N812",
-"N815",
-"N816",
-"N999",
-"D107",
-"D105",
-"D102",
-"D104",
-"D100",
-"D200",
-"D205",
-"D400",
+    "N802",
+    "N803",
+    "N806",
+    "N812",
+    "N815",
+    "N816",
+    "N999",
+    "D107",
+    "D105",
+    "D102",
+    "D104",
+    "D100",
+    "D200",
+    "D205",
+    "D400",
 ]
 line-length = 110
 select = [
-"E",  # pycodestyle
-"F",  # pycodestyle
-"N",  # pep8-naming
-"W",  # pycodestyle
-"D",  # pydocstyle
+    "E",  # pycodestyle
+    "F",  # pycodestyle
+    "N",  # pep8-naming
+    "W",  # pycodestyle
+    "D",  # pydocstyle
 ]
 target-version = "py311"
 extend-select = [
-"RUF100", # Warn about unused noqa
+    "RUF100", # Warn about unused noqa
 ]
 
 [tool.ruff.per-file-ignores]

--- a/python/lsst/dax/apdb/__init__.py
+++ b/python/lsst/dax/apdb/__init__.py
@@ -28,3 +28,4 @@ from .apdbSql import *
 from .apdbSqlSchema import *
 from .factory import *
 from .version import *
+from .versionTuple import *

--- a/python/lsst/dax/apdb/__init__.py
+++ b/python/lsst/dax/apdb/__init__.py
@@ -22,6 +22,7 @@
 from .apdb import *
 from .apdbCassandra import *
 from .apdbCassandraSchema import *
+from .apdbMetadata import *
 from .apdbSchema import *
 from .apdbSql import *
 from .apdbSqlSchema import *

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -27,6 +27,7 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
 import lsst.daf.base as dafBase
@@ -36,6 +37,9 @@ from lsst.pex.config import Config, ConfigurableField, Field
 from lsst.sphgeom import Region
 
 from .apdbSchema import ApdbTables
+
+if TYPE_CHECKING:
+    from .apdbMetadata import ApdbMetadata
 
 
 def _data_file_name(basename: str) -> str:
@@ -495,3 +499,9 @@ class Apdb(ABC):
             A `~lsst.pex.config.ConfigurableField` for Apdb.
         """
         return ConfigurableField(doc=doc, target=cls)
+
+    @property
+    @abstractmethod
+    def metadata(self) -> ApdbMetadata:
+        """Object controlling access to APDB metadata (`ApdbMetadata`)."""
+        raise NotImplementedError()

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -40,6 +40,7 @@ from .apdbSchema import ApdbTables
 
 if TYPE_CHECKING:
     from .apdbMetadata import ApdbMetadata
+    from .versionTuple import VersionTuple
 
 
 def _data_file_name(basename: str) -> str:
@@ -127,6 +128,29 @@ class Apdb(ABC):
     """Abstract interface for APDB."""
 
     ConfigClass = ApdbConfig
+
+    @classmethod
+    @abstractmethod
+    def apdbImplementationVersion(cls) -> VersionTuple:
+        """Return version number for current APDB implementation.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Version of the code defined in implementation class.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def apdbSchemaVersion(self) -> VersionTuple:
+        """Return schema version number as defined in config file.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Version of the schema defined in schema config file.
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def tableDef(self, table: ApdbTables) -> Table | None:

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -26,7 +26,7 @@ __all__ = ["ApdbCassandraConfig", "ApdbCassandra"]
 import logging
 import uuid
 from collections.abc import Iterable, Iterator, Mapping, Set
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas
@@ -65,6 +65,9 @@ from .cassandra_utils import (
 )
 from .pixelization import Pixelization
 from .timer import Timer
+
+if TYPE_CHECKING:
+    from .apdbMetadata import ApdbMetadata
 
 _LOG = logging.getLogger(__name__)
 
@@ -587,6 +590,11 @@ class ApdbCassandra(Apdb):
 
         # It's too inefficient to implement it for Cassandra in current schema.
         raise NotImplementedError()
+
+    @property
+    def metadata(self) -> ApdbMetadata:
+        # docstring is inherited from a base class
+        raise NotImplementedError("Metadata is not yet implemented for Cassandra backend")
 
     def _makeProfiles(self, config: ApdbCassandraConfig) -> Mapping[Any, ExecutionProfile]:
         """Make all execution profiles used in the code."""

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -65,11 +65,17 @@ from .cassandra_utils import (
 )
 from .pixelization import Pixelization
 from .timer import Timer
+from .versionTuple import VersionTuple
 
 if TYPE_CHECKING:
     from .apdbMetadata import ApdbMetadata
 
 _LOG = logging.getLogger(__name__)
+
+VERSION = VersionTuple(0, 1, 0)
+"""Version for the code defined in this module. This needs to be updated
+(following compatibility rules) when schema produced by this code changes.
+"""
 
 # Copied from daf_butler.
 DB_AUTH_ENVVAR = "LSST_DB_AUTH"
@@ -290,6 +296,15 @@ class ApdbCassandra(Apdb):
             )
 
         return None
+
+    @classmethod
+    def apdbImplementationVersion(cls) -> VersionTuple:
+        # Docstring inherited from base class.
+        return VERSION
+
+    def apdbSchemaVersion(self) -> VersionTuple:
+        # Docstring inherited from base class.
+        return self._schema.schemaVersion()
 
     def tableDef(self, table: ApdbTables) -> Table | None:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/apdbMetadata.py
+++ b/python/lsst/dax/apdb/apdbMetadata.py
@@ -1,0 +1,121 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbMetadata"]
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+
+
+class ApdbMetadata(ABC):
+    """Interface for accessing APDB metadata.
+
+    Metadata is a collection of key/value items usually stored in a special
+    table in the database. This abstract interface provides methods for
+    accessing and modifying it.
+    """
+
+    @abstractmethod
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Retrieve value of a given metadata record.
+
+        Parameters
+        ----------
+        key : `str`
+            Metadata key, arbitrary non-empty string.
+        default : `str`, optional
+            Default value returned when key does not exist, can be string
+            or `None`.
+
+        Returns
+        -------
+        value : `str` or `None`
+            Metadata value, if key does not exist then ``default`` is returned.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def set(self, key: str, value: str, *, force: bool = False) -> None:
+        """Set value for a given metadata record.
+
+        Parameters
+        ----------
+        key : `str`
+            Metadata key, arbitrary non-empty string.
+        value : `str`
+            New metadata value, an arbitrary string. Due to deficiencies of
+            some database engines we are not allowing empty strings to be
+            stored in the database, and ``value`` cannot be an empty string.
+        force : `bool`, optional
+            Controls handling of existing metadata. With default `False`
+            value an exception is raised if ``key`` already exists, if `True`
+            is passed then value of the existing key will be updated.
+
+        Raises
+        ------
+        KeyError
+            Raised if key already exists but ``force`` option is false.
+        ValueError
+            Raised if key or value parameters are empty.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def delete(self, key: str) -> bool:
+        """Delete metadata record.
+
+        Parameters
+        ----------
+        key : `str`
+            Metadata key, arbitrary non-empty string.
+
+        Returns
+        -------
+        existed : `bool`
+            `True` is returned if attribute existed before it was deleted.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def items(self) -> Generator[tuple[str, str], None, None]:
+        """Iterate over records and yield their keys and values.
+
+        Yields
+        ------
+        key : `str`
+            Metadata key.
+        value : `str`
+            Corresponding metadata value.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def empty(self) -> bool:
+        """Check whether attributes set is empty.
+
+        Returns
+        -------
+        empty : `bool`
+            True if there are no any attributes defined.
+        """
+        raise NotImplementedError()

--- a/python/lsst/dax/apdb/apdbMetadata.py
+++ b/python/lsst/dax/apdb/apdbMetadata.py
@@ -116,6 +116,7 @@ class ApdbMetadata(ABC):
         Returns
         -------
         empty : `bool`
-            True if there are no any attributes defined.
+            `True` if there are no any attributes defined. `True` is also
+            returned if metadata table is missing.
         """
         raise NotImplementedError()

--- a/python/lsst/dax/apdb/apdbMetadataCassandra.py
+++ b/python/lsst/dax/apdb/apdbMetadataCassandra.py
@@ -1,0 +1,149 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbMetadataCassandra"]
+
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any
+
+from .apdbMetadata import ApdbMetadata
+from .apdbSchema import ApdbTables
+from .cassandra_utils import PreparedStatementCache, quote_id
+
+if TYPE_CHECKING:
+    from .apdbCassandra import ApdbCassandraConfig
+    from .apdbCassandraSchema import ApdbCassandraSchema
+
+
+class ApdbMetadataCassandra(ApdbMetadata):
+    """Implementation of `ApdbMetadata` for Cassandra backend.
+
+    Parameters
+    ----------
+    session : `cassandra.cluster.Session`
+        Cassandra session instance.
+    schema : `ApdbSqlSchema`
+        Object providing access to schema details.
+    """
+
+    def __init__(self, session: Any, schema: ApdbCassandraSchema, config: ApdbCassandraConfig):
+        self._session = session
+        self._config = config
+        self._part = 0  # Partition for all rows
+        self._preparer = PreparedStatementCache(session)
+        # _table_clause will be None when metadata table is not configured
+        self._table_clause: str | None = None
+        if ApdbTables.metadata in schema.tableSchemas:
+            table_name = schema.tableName(ApdbTables.metadata)
+            keyspace = schema.keyspace()
+            if not keyspace:
+                self._table_clause = quote_id(table_name)
+            else:
+                self._table_clause = f"{quote_id(keyspace)}.{quote_id(table_name)}"
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        # Docstring is inherited.
+        if self._table_clause is None:
+            return default
+        query = f"SELECT value FROM {self._table_clause} WHERE meta_part = ? AND name = ?"
+        result = self._session.execute(
+            self._preparer.prepare(query),
+            (self._part, key),
+            timeout=self._config.read_timeout,
+            execution_profile="read_tuples",
+        )
+        if (row := result.one()) is not None:
+            return row[0]
+        else:
+            return default
+
+    def set(self, key: str, value: str, *, force: bool = False) -> None:
+        # Docstring is inherited.
+        if self._table_clause is None:
+            raise RuntimeError("Metadata table does not exist")
+        if not key or not value:
+            raise ValueError("name and value cannot be empty")
+        query = f"INSERT INTO {self._table_clause} (meta_part, name, value) VALUES (?, ?, ?)"
+        if not force and self.get(key) is not None:
+            raise KeyError(f"Metadata key {key!r} already exists")
+        # Race is still possible between check and insert.
+        self._session.execute(
+            self._preparer.prepare(query),
+            (self._part, key, value),
+            timeout=self._config.write_timeout,
+            execution_profile="write",
+        )
+
+    def delete(self, key: str) -> bool:
+        # Docstring is inherited.
+        if self._table_clause is None:
+            # Missing table means nothing to delete.
+            return False
+        if not key:
+            raise ValueError("name cannot be empty")
+        query = f"DELETE FROM {self._table_clause} WHERE meta_part = ? AND name = ?"
+        # Cassandra cannot tell how many rows are deleted, just check if row
+        # exists now.
+        exists = self.get(key) is not None
+        # Race is still possible between check and remove.
+        self._session.execute(
+            self._preparer.prepare(query),
+            (self._part, key),
+            timeout=self._config.write_timeout,
+            execution_profile="write",
+        )
+        return exists
+
+    def items(self) -> Generator[tuple[str, str], None, None]:
+        # Docstring is inherited.
+        if self._table_clause is None:
+            # Missing table means nothing to return.
+            return
+        query = f"SELECT name, value FROM {self._table_clause} WHERE meta_part = ?"
+        result = self._session.execute(
+            self._preparer.prepare(query),
+            (self._part,),
+            timeout=self._config.read_timeout,
+            execution_profile="read_tuples",
+        )
+        for row in result:
+            yield tuple(row)
+
+    def empty(self) -> bool:
+        # Docstring is inherited.
+        if self._table_clause is None:
+            # Missing table means empty.
+            return True
+        query = f"SELECT count(*) FROM {self._table_clause} WHERE meta_part = ?"
+        result = self._session.execute(
+            self._preparer.prepare(query),
+            (self._part,),
+            timeout=self._config.read_timeout,
+            execution_profile="read_tuples",
+        )
+        row = result.one()
+        return row[0] == 0
+
+    def table_exists(self) -> bool:
+        """Return `True` if metadata table exists."""
+        return self._table_clause is not None

--- a/python/lsst/dax/apdb/apdbMetadataSql.py
+++ b/python/lsst/dax/apdb/apdbMetadataSql.py
@@ -1,0 +1,121 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbMetadata"]
+
+from collections.abc import Generator
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+import sqlalchemy
+
+from .apdbMetadata import ApdbMetadata
+from .apdbSchema import ApdbTables
+
+if TYPE_CHECKING:
+    from .apdbSqlSchema import ApdbSqlSchema
+
+
+class ApdbMetadataSql(ApdbMetadata):
+    """Implementation of `ApdbMetadata` for SQL backend.
+
+    Parameters
+    ----------
+    engine : `sqlalchemy.engine.Engine`
+        Database access engine.
+    schema : `ApdbSqlSchema`
+        Object providing access to schema details.
+    """
+
+    def __init__(self, engine: sqlalchemy.engine.Engine, schema: ApdbSqlSchema):
+        self._engine = engine
+        # Metadata table may not exist for old databases.
+        self._table: sqlalchemy.schema.Table | None = None
+        with suppress(ValueError):
+            self._table = schema.get_table(ApdbTables.metadata)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        # Docstring is inherited.
+        if self._table is None:
+            return default
+        sql = sqlalchemy.sql.select(self._table.columns.value).where(self._table.columns.name == key)
+        with self._engine.begin() as conn:
+            result = conn.execute(sql)
+            value = result.scalar()
+        if value is not None:
+            return value
+        return default
+
+    def set(self, key: str, value: str, *, force: bool = False) -> None:
+        # Docstring is inherited.
+        if self._table is None:
+            raise RuntimeError("Metadata table does not exist")
+        if not key or not value:
+            raise ValueError("name and value cannot be empty")
+        try:
+            insert = sqlalchemy.sql.insert(self._table).values(name=key, value=value)
+            with self._engine.begin() as conn:
+                conn.execute(insert)
+        except sqlalchemy.exc.IntegrityError as exc:
+            # Try to update if it exists.
+            if not force:
+                raise KeyError(f"Metadata key {key!r} already exists") from exc
+            update = (
+                sqlalchemy.sql.update(self._table).where(self._table.columns.name == key).values(value=value)
+            )
+            with self._engine.begin() as conn:
+                result = conn.execute(update)
+                if result.rowcount != 1:
+                    raise RuntimeError(f"Metadata update failed unexpectedly, count={result.rowcount}")
+
+    def delete(self, key: str) -> bool:
+        # Docstring is inherited.
+        if self._table is None:
+            # Missing table means nothing to delete.
+            return False
+        stmt = sqlalchemy.sql.delete(self._table).where(self._table.columns.name == key)
+        with self._engine.begin() as conn:
+            result = conn.execute(stmt)
+            return result.rowcount > 0
+
+    def items(self) -> Generator[tuple[str, str], None, None]:
+        # Docstring is inherited.
+        if self._table is None:
+            # Missing table means nothing to return.
+            return
+        stmt = sqlalchemy.sql.select(self._table.columns.name, self._table.columns.value)
+        with self._engine.begin() as conn:
+            result = conn.execute(stmt)
+            for row in result:
+                yield row._tuple()
+
+    def empty(self) -> bool:
+        # Docstring is inherited.
+        if self._table is None:
+            # Missing table means empty.
+            return True
+        stmt = sqlalchemy.sql.select(sqlalchemy.sql.func.count()).select_from(self._table)
+        with self._engine.begin() as conn:
+            result = conn.execute(stmt)
+            count = result.scalar()
+        return count == 0

--- a/python/lsst/dax/apdb/apdbMetadataSql.py
+++ b/python/lsst/dax/apdb/apdbMetadataSql.py
@@ -24,16 +24,10 @@ from __future__ import annotations
 __all__ = ["ApdbMetadataSql"]
 
 from collections.abc import Generator
-from contextlib import suppress
-from typing import TYPE_CHECKING
 
 import sqlalchemy
 
 from .apdbMetadata import ApdbMetadata
-from .apdbSchema import ApdbTables
-
-if TYPE_CHECKING:
-    from .apdbSqlSchema import ApdbSqlSchema
 
 
 class ApdbMetadataSql(ApdbMetadata):
@@ -43,16 +37,14 @@ class ApdbMetadataSql(ApdbMetadata):
     ----------
     engine : `sqlalchemy.engine.Engine`
         Database access engine.
-    schema : `ApdbSqlSchema`
-        Object providing access to schema details.
+    table : `sqlalchemy.schema.Table` or `None`
+        Database table holding metadata. If table does not exists then `None`
+        should be specified.
     """
 
-    def __init__(self, engine: sqlalchemy.engine.Engine, schema: ApdbSqlSchema):
+    def __init__(self, engine: sqlalchemy.engine.Engine, table: sqlalchemy.schema.Table | None):
         self._engine = engine
-        # Metadata table may not exist for old databases.
-        self._table: sqlalchemy.schema.Table | None = None
-        with suppress(ValueError):
-            self._table = schema.get_table(ApdbTables.metadata)
+        self._table = table
 
     def get(self, key: str, default: str | None = None) -> str | None:
         # Docstring is inherited.

--- a/python/lsst/dax/apdb/apdbMetadataSql.py
+++ b/python/lsst/dax/apdb/apdbMetadataSql.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["ApdbMetadata"]
+__all__ = ["ApdbMetadataSql"]
 
 from collections.abc import Generator
 from contextlib import suppress
@@ -119,3 +119,7 @@ class ApdbMetadataSql(ApdbMetadata):
             result = conn.execute(stmt)
             count = result.scalar()
         return count == 0
+
+    def table_exists(self) -> bool:
+        """Return `True` if metadata table exists."""
+        return self._table is not None

--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -87,6 +87,9 @@ class ApdbTables(enum.Enum):
     DiaObject_To_Object_Match = "DiaObject_To_Object_Match"
     """Name of the table for DiaObject_To_Object_Match records."""
 
+    metadata = "metadata"
+    """Name of the metadata table, this table may not always exist."""
+
     def table_name(self, prefix: str = "") -> str:
         """Return full table name."""
         return prefix + self.value

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -48,6 +48,7 @@ from .apdbMetadataSql import ApdbMetadataSql
 from .apdbSchema import ApdbTables
 from .apdbSqlSchema import ApdbSqlSchema, ExtraTables
 from .timer import Timer
+from .versionTuple import IncompatibleVersionError, VersionTuple
 
 if TYPE_CHECKING:
     import sqlite3
@@ -56,6 +57,10 @@ if TYPE_CHECKING:
 
 _LOG = logging.getLogger(__name__)
 
+VERSION = VersionTuple(0, 1, 0)
+"""Version for the code defined in this module. This needs to be updated
+(following compatibility rules) when schema produced by this code changes.
+"""
 
 if pandas.__version__.partition(".")[0] == "1":
 
@@ -238,6 +243,12 @@ class ApdbSql(Apdb):
 
     ConfigClass = ApdbSqlConfig
 
+    metadataSchemaVersionKey = "version:schema"
+    """Name of the metadata key to store schema version number."""
+
+    metadataCodeVersionKey = "version:ApdbSql"
+    """Name of the metadata key to store code version number."""
+
     def __init__(self, config: ApdbSqlConfig):
         config.validate()
         self.config = config
@@ -286,8 +297,51 @@ class ApdbSql(Apdb):
         )
         self._metadata = ApdbMetadataSql(self._engine, self._schema)
 
+        self._versionCheck()
+
         self.pixelator = HtmPixelization(self.config.htm_level)
         self.use_insert_id = self._schema.has_insert_id
+
+    def _versionCheck(self) -> None:
+        """Check schema version compatibility."""
+
+        def _get_version(key: str, default: VersionTuple) -> VersionTuple:
+            """Retrieve version number from given metadata key."""
+            if self._metadata.table_exists():
+                version_str = self._metadata.get(key)
+                if version_str is None:
+                    # Should not happen with existing metadata table.
+                    raise RuntimeError(f"Version key {key!r} does not exist in metadata table.")
+                return VersionTuple.fromString(version_str)
+            return default
+
+        # For old databases where metadata table does not exist we assume that
+        # version of both code and schema is 0.1.0.
+        initial_version = VersionTuple(0, 1, 0)
+        db_schema_version = _get_version(self.metadataSchemaVersionKey, initial_version)
+        db_code_version = _get_version(self.metadataCodeVersionKey, initial_version)
+
+        # For now there is no way to make read-only APDB instances, assume that
+        # any access can do updates.
+        if not self._schema.schemaVersion().checkCompatibility(db_schema_version, True):
+            raise IncompatibleVersionError(
+                f"Configured schema version {self._schema.schemaVersion()} "
+                f"is not compatible with database version {db_schema_version}"
+            )
+        if not self.apdbImplementationVersion().checkCompatibility(db_code_version, True):
+            raise IncompatibleVersionError(
+                f"Current code version {self.apdbImplementationVersion()} "
+                f"is not compatible with database version {db_code_version}"
+            )
+
+    @classmethod
+    def apdbImplementationVersion(cls) -> VersionTuple:
+        # Docstring inherited from base class.
+        return VERSION
+
+    def apdbSchemaVersion(self) -> VersionTuple:
+        # Docstring inherited from base class.
+        return self._schema.schemaVersion()
 
     def tableRowCount(self) -> dict[str, int]:
         """Return dictionary with the table names and row counts.
@@ -322,6 +376,13 @@ class ApdbSql(Apdb):
         self._schema.makeSchema(drop=drop)
         # Need to reset metadata after table was created.
         self._metadata = ApdbMetadataSql(self._engine, self._schema)
+
+        if self._metadata.table_exists():
+            # Fill version numbers, but only if they are not defined.
+            if self._metadata.get(self.metadataSchemaVersionKey) is None:
+                self._metadata.set(self.metadataSchemaVersionKey, str(self._schema.schemaVersion()))
+            if self._metadata.get(self.metadataCodeVersionKey) is None:
+                self._metadata.set(self.metadataCodeVersionKey, str(self.apdbImplementationVersion()))
 
     def getDiaObjects(self, region: Region) -> pandas.DataFrame:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/apdbSqlSchema.py
+++ b/python/lsst/dax/apdb/apdbSqlSchema.py
@@ -210,7 +210,7 @@ class ApdbSqlSchema(ApdbSchema):
             felis.types.Short: sqlalchemy.types.Integer,
             felis.types.Byte: sqlalchemy.types.Integer,
             felis.types.Binary: sqlalchemy.types.LargeBinary,
-            felis.types.Text: sqlalchemy.types.CHAR,
+            felis.types.Text: sqlalchemy.types.Text,
             felis.types.String: sqlalchemy.types.CHAR,
             felis.types.Char: sqlalchemy.types.CHAR,
             felis.types.Unicode: sqlalchemy.types.CHAR,
@@ -251,6 +251,7 @@ class ApdbSqlSchema(ApdbSchema):
         self._extra_tables = self._make_extra_tables(self._apdb_tables)
 
         self._has_insert_id: bool | None = None
+        self._metadata_check: bool | None = None
 
     def makeSchema(self, drop: bool = False) -> None:
         """Create or re-create all tables.
@@ -279,6 +280,7 @@ class ApdbSqlSchema(ApdbSchema):
 
         # Reset possibly cached value.
         self._has_insert_id = None
+        self._metadata_check = None
 
     def get_table(self, table_enum: ApdbTables | ExtraTables) -> Table:
         """Return SQLAlchemy table instance for a specified table type/enum.
@@ -300,6 +302,18 @@ class ApdbSqlSchema(ApdbSchema):
         """
         try:
             if isinstance(table_enum, ApdbTables):
+                if table_enum is ApdbTables.metadata:
+                    # There may be cases when schema is configured with the
+                    # metadata table but database is still missing it. Check
+                    # that table actually exists in the database. Note that
+                    # this may interact with `makeSchema`.
+                    if self._metadata_check is None:
+                        inspector = inspect(self._engine)
+                        table_name = table_enum.table_name(self._prefix)
+                        self._metadata_check = inspector.has_table(table_name, schema=self._metadata.schema)
+                    if not self._metadata_check:
+                        # this will be caught below
+                        raise LookupError("metadata table is missing")
                 return self._apdb_tables[table_enum]
             else:
                 return self._extra_tables[table_enum]
@@ -357,6 +371,9 @@ class ApdbSqlSchema(ApdbSchema):
         tables = {}
         for table_enum in ApdbTables:
             if table_enum is ApdbTables.DiaObjectLast and self._dia_object_index != "last_object_table":
+                continue
+            if table_enum is ApdbTables.metadata and table_enum not in self.tableSchemas:
+                # Schema does not define metadata.
                 continue
 
             columns = self._tableColumns(table_enum)

--- a/python/lsst/dax/apdb/versionTuple.py
+++ b/python/lsst/dax/apdb/versionTuple.py
@@ -1,0 +1,121 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = [
+    "IncompatibleVersionError",
+    "VersionTuple",
+]
+
+from typing import NamedTuple
+
+
+class IncompatibleVersionError(RuntimeError):
+    """Exception raised when version numbers are not compatible."""
+
+
+class VersionTuple(NamedTuple):
+    """Class representing a version number.
+
+    Parameters
+    ----------
+    major, minor, patch : `int`
+        Version number components
+    """
+
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def fromString(cls, versionStr: str) -> VersionTuple:
+        """Extract version number from a string.
+
+        Parameters
+        ----------
+        versionStr : `str`
+            Version number in string form "X.Y.Z", all components must be
+            present.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Parsed version tuple.
+
+        Raises
+        ------
+        ValueError
+            Raised if string has an invalid format.
+        """
+        try:
+            version = tuple(int(v) for v in versionStr.split("."))
+        except ValueError as exc:
+            raise ValueError(f"Invalid version  string '{versionStr}'") from exc
+        if len(version) != 3:
+            raise ValueError(f"Invalid version  string '{versionStr}', must consist of three numbers")
+        return cls(*version)
+
+    def checkCompatibility(self, database_version: VersionTuple, update: bool) -> bool:
+        """Compare implementation schema version with schema version in
+        database.
+
+        Parameters
+        ----------
+        database_version : `VersionTuple`
+            Version of the database schema.
+        update : `bool`
+            If True then read-write access is expected.
+
+        Returns
+        -------
+        compatible : `bool`
+            True if schema versions are compatible.
+
+        Notes
+        -----
+        This method implements default rules for checking schema compatibility:
+
+            - if major numbers differ, schemas are not compatible;
+            - otherwise, if minor versions are different then newer version can
+              read schema made by older version, but cannot write into it;
+              older version can neither read nor write into newer schema;
+            - otherwise, different patch versions are totally compatible.
+        """
+        if self.major != database_version.major:
+            # different major versions are not compatible at all
+            return False
+        if self.minor != database_version.minor:
+            # different minor versions are backward compatible for read
+            # access only
+            return self.minor > database_version.minor and not update
+        # patch difference does not matter
+        return True
+
+    def __str__(self) -> str:
+        """Transform version tuple into a canonical string form."""
+        return f"{self.major}.{self.minor}.{self.patch}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyyaml >= 5.1
 sqlalchemy
 # daf_base cannot be installed
 # git+https://github.com/lsst/daf_base@main#egg=lsst-daf-base
-git+https://github.com/lsst/felis@main#egg=felis
+git+https://github.com/lsst/felis@main#egg=lsst-felis
 git+https://github.com/lsst/pex_config@main#egg=lsst-pex-config
 git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom
 git+https://github.com/lsst/utils@main#egg=lsst-utils

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -1,7 +1,23 @@
 ---
 name: "ApdbSchema"
 "@id": "#apdbSchema"
+version: "0.1.1"
 tables:
+- name: metadata
+  "@id": "#metadata"
+  description: Table containing various metadata key/value pairs for APDB.
+  columns:
+  - name: name
+    "@id": "#metadata.name"
+    datatype: text
+    nullable: false
+    description: Name or key for a metadata item.
+  - name: value
+    "@id": "#metadata.value"
+    datatype: text
+    nullable: false
+    description: Content of the metadata item in string representation.
+  primaryKey: "#metadata.name"
 - name: DiaObject
   "@id": "#DiaObject"
   description: The DiaObject table contains descriptions of the astronomical objects

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -10,11 +10,13 @@ tables:
   - name: name
     "@id": "#metadata.name"
     datatype: text
+    length: 1024
     nullable: false
     description: Name or key for a metadata item.
   - name: value
     "@id": "#metadata.value"
     datatype: text
+    length: 65535
     nullable: false
     description: Content of the metadata item in string representation.
   primaryKey: "#metadata.name"
@@ -102,7 +104,7 @@ tables:
     datatype: float
     description: Arc of observation.
     mysql:datatype: FLOAT
-    fits:tunit: days
+    fits:tunit: day
   - name: flags
     "@id": "#SSObject.flags"
     datatype: long

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -94,7 +94,7 @@ class ApdbCassandraMixin:
             ...
 
 
-class ApdbCassandraTestCase(ApdbCassandraMixin, unittest.TestCase, ApdbTest):
+class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     """A test case for ApdbCassandra class"""
 
     allow_visit_query = False
@@ -137,7 +137,7 @@ class ApdbCassandraTestCaseInsertIds(ApdbCassandraTestCase):
     use_insert_id = True
 
 
-class ApdbSchemaUpdateCassandraTestCase(ApdbCassandraMixin, unittest.TestCase, ApdbSchemaUpdateTest):
+class ApdbSchemaUpdateCassandraTestCase(ApdbCassandraMixin, ApdbSchemaUpdateTest, unittest.TestCase):
     """A test case for schema updates using Cassandra backend."""
 
     def make_config(self, **kwargs: Any) -> ApdbCassandraConfig:

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -41,7 +41,7 @@ except ImportError:
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
 
 
-class ApdbSQLiteTestCase(unittest.TestCase, ApdbTest):
+class ApdbSQLiteTestCase(ApdbTest, unittest.TestCase):
     """A test case for ApdbSql class using SQLite backend."""
 
     fsrc_requires_id_list = True
@@ -91,7 +91,7 @@ class ApdbSQLiteTestCaseInsertIds(ApdbSQLiteTestCase):
 
 
 @unittest.skipUnless(testing is not None, "testing.postgresql module not found")
-class ApdbPostgresTestCase(unittest.TestCase, ApdbTest):
+class ApdbPostgresTestCase(ApdbTest, unittest.TestCase):
     """A test case for ApdbSql class using Postgres backend."""
 
     fsrc_requires_id_list = True
@@ -148,7 +148,7 @@ class ApdbPostgresNamespaceTestCase(ApdbPostgresTestCase):
         return super().make_config(namespace=self.namespace, **kwargs)
 
 
-class ApdbSchemaUpdateSQLiteTestCase(unittest.TestCase, ApdbSchemaUpdateTest):
+class ApdbSchemaUpdateSQLiteTestCase(ApdbSchemaUpdateTest, unittest.TestCase):
     """A test case for schema updates using SQLite backend."""
 
     def setUp(self) -> None:


### PR DESCRIPTION
Apdb now understands `metadata` table specification in sdm_schemas. Apdb now verifies that its own version and schema version in sdm_schemas are compatible with the versions stored in metadata table. Both metadata table and sdm_schemas version numbers are optional, if they are missing they are assumed to be "0.1.0".