### PR TITLE
DM-42489: Freeze APDB configuration in metadata table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.14
+    rev: v0.2.0
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -169,16 +169,23 @@ class Apdb(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
-    def makeSchema(self, drop: bool = False) -> None:
+    @classmethod
+    def makeSchema(cls, config: ApdbConfig, *, drop: bool = False) -> None:
         """Create or re-create whole database schema.
 
         Parameters
         ----------
+        config : `ApdbConfig`
+            Instance of configuration class, the type has to match the type of
+            the actual implementation class of this interface.
         drop : `bool`
             If True then drop all tables before creating new ones.
         """
-        raise NotImplementedError()
+        # Dispatch to actual implementation class based on config type.
+        from .factory import apdb_type
+
+        klass = apdb_type(config)
+        klass.makeSchema(config, drop=drop)
 
     @abstractmethod
     def getDiaObjects(self, region: Region) -> pandas.DataFrame:

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -137,7 +137,7 @@ class ApdbCassandraConfig(ApdbConfig):
     ra_dec_columns = ListField[str](default=["ra", "dec"], doc="Names of ra/dec columns in DiaObject table")
     timer = Field[bool](doc="If True then print/log timing information", default=False)
     time_partition_tables = Field[bool](
-        doc="Use per-partition tables for sources instead of partitioning by time", default=True
+        doc="Use per-partition tables for sources instead of partitioning by time", default=False
     )
     time_partition_days = Field[int](
         doc=(

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -313,7 +313,12 @@ class ApdbCassandraSchema(ApdbSchema):
         missing_tables = []
         for table_enum in self._apdb_tables:
             table_name = table_enum.table_name(self._prefix)
-            if table_name in table_names:
+            if self._time_partition_tables and table_enum in self._time_partitioned_tables:
+                # Check prefix for time-partitioned tables.
+                exists = any(table.startswith(f"{table_name}_") for table in table_names)
+            else:
+                exists = table_name in table_names
+            if exists:
                 existing_tables.append(table_name)
             else:
                 missing_tables.append(table_name)

--- a/python/lsst/dax/apdb/apdbConfigFreezer.py
+++ b/python/lsst/dax/apdb/apdbConfigFreezer.py
@@ -1,0 +1,98 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbConfigFreezer"]
+
+import json
+from collections.abc import Iterable
+from typing import Generic, TypeVar
+
+from .apdb import ApdbConfig
+
+_Config = TypeVar("_Config", bound=ApdbConfig)
+
+
+class ApdbConfigFreezer(Generic[_Config]):
+    """Class that handles freezing of the configuration parameters, this is
+    an implementation detail for use in Apdb subclasses.
+
+    Parameters
+    ----------
+    field_names : `~collections.abc.Iterable` [`str`]
+        Names of configuration fields to be frozen.
+    """
+
+    def __init__(self, field_names: Iterable[str]):
+        self._field_names = list(field_names)
+
+    def to_json(self, config: ApdbConfig) -> str:
+        """Convert part of the configuration object to JSON string.
+
+        Parameters
+        ----------
+        config : `ApdbConfig`
+            Configuration object.
+
+        Returns
+        -------
+        json_str : `str`
+            JSON representation of the frozen part of the config.
+        """
+        config_dict = config.toDict()
+        json_dict = {name: config_dict[name] for name in self._field_names}
+        return json.dumps(json_dict)
+
+    def update(self, config: _Config, json_str: str) -> _Config:
+        """Update configuration field values from a JSON string.
+
+        Parameters
+        ----------
+        config : `ApdbConfig`
+            Configuration object.
+        json_str : str
+            String containing JSON representation of configuration.
+
+        Returns
+        -------
+        updated : `ApdbConfig`
+            Copy of the ``config`` with some fields updated from JSON object.
+
+        Raises
+        ------
+        TypeError
+            Raised if JSON string does not represent JSON object.
+        ValueError
+            Raised if JSON object contains key which is not present in
+            ``field_names``.
+        """
+        data = json.loads(json_str)
+        if not isinstance(data, dict):
+            raise TypeError(f"JSON string must be convertible to object: {json_str!r}")
+
+        new_config = type(config)(**config.toDict())
+        for key, value in data.items():
+            if key not in self._field_names:
+                raise ValueError(f"JSON object contains unknown key: {key}")
+            setattr(new_config, key, value)
+
+        return new_config

--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -158,15 +158,14 @@ class ApdbSchema:
         else:
             return self._schemaVersion
 
+    @classmethod
     def _buildSchemas(
-        self,
-        schema_file: str,
-        schema_name: str = "ApdbSchema",
+        cls, schema_file: str, schema_name: str = "ApdbSchema"
     ) -> tuple[Mapping[ApdbTables, Table], VersionTuple | None]:
         """Create schema definitions for all tables.
 
-        Reads YAML schemas and builds dictionary containing `TableDef`
-        instances for each table.
+        Reads YAML schema and builds a dictionary containing
+        `felis.simple.Table` instances for each table.
 
         Parameters
         ----------
@@ -177,8 +176,8 @@ class ApdbSchema:
 
         Returns
         -------
-        schemas : `dict`
-            Mapping of table names to `TableDef` instances.
+        tables : `dict`
+            Mapping of table names to `felis.simple.Table` instances.
         version : `VersionTuple` or `None`
             Schema version defined in schema file, `None` if version is not
             defined.
@@ -197,7 +196,7 @@ class ApdbSchema:
             schema = visitor.visit_schema(schema_dict)
 
         # convert all dicts into classes
-        schemas: MutableMapping[ApdbTables, Table] = {}
+        tables: MutableMapping[ApdbTables, Table] = {}
         for table in schema.tables:
             try:
                 table_enum = ApdbTables(table.name)
@@ -206,10 +205,10 @@ class ApdbSchema:
                 # to APDB.
                 continue
             else:
-                schemas[table_enum] = table
+                tables[table_enum] = table
 
         version: VersionTuple | None = None
         if schema.version is not None:
             version = VersionTuple.fromString(schema.version.current)
 
-        return schemas, version
+        return tables, version

--- a/python/lsst/dax/apdb/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra_utils.py
@@ -248,11 +248,15 @@ def select_concurrent(
             else:
                 _LOG.error("error returned by query: %s", result)
                 raise result
-        # concatenate all frames
-        if len(dataframes) == 1:
+        # Concatenate all frames, but skip empty ones.
+        non_empty = [df for df in dataframes if not df.empty]
+        if not non_empty:
+            # If all frames are empty, return the first one.
             catalog = dataframes[0]
+        elif len(non_empty) == 1:
+            catalog = non_empty[0]
         else:
-            catalog = pandas.concat(dataframes)
+            catalog = pandas.concat(non_empty)
         _LOG.debug("pandas catalog shape: %s", catalog.shape)
         return catalog
 

--- a/python/lsst/dax/apdb/factory.py
+++ b/python/lsst/dax/apdb/factory.py
@@ -21,11 +21,36 @@
 
 from __future__ import annotations
 
-__all__ = ["make_apdb"]
+__all__ = ["apdb_type", "make_apdb"]
 
 from .apdb import Apdb, ApdbConfig
 from .apdbCassandra import ApdbCassandra, ApdbCassandraConfig
 from .apdbSql import ApdbSql, ApdbSqlConfig
+
+
+def apdb_type(config: ApdbConfig) -> type[ApdbSql | ApdbCassandra]:
+    """Return Apdb type on Apdb configuration.
+
+    Parameters
+    ----------
+    config : `ApdbConfig`
+        Configuration object, sub-class of ApdbConfig.
+
+    Returns
+    -------
+    type : `type` [`Apdb`]
+        Subclass of `Apdb` class.
+
+    Raises
+    ------
+    TypeError
+        Raised if type of ``config`` does not match any known types.
+    """
+    if type(config) is ApdbSqlConfig:
+        return ApdbSql
+    elif type(config) is ApdbCassandraConfig:
+        return ApdbCassandra
+    raise TypeError(f"Unknown type of config object: {type(config)}")
 
 
 def make_apdb(config: ApdbConfig) -> Apdb:

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -35,6 +35,7 @@ import pandas
 import yaml
 from lsst.daf.base import DateTime
 from lsst.dax.apdb import (
+    Apdb,
     ApdbConfig,
     ApdbInsertId,
     ApdbSql,
@@ -188,9 +189,9 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_makeSchema(self) -> None:
         """Test for making APDB schema."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
 
-        apdb.makeSchema()
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObjectLast))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaSource))
@@ -205,8 +206,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """
         # use non-zero months for Forced/Source fetching
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -264,8 +265,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """
         # set read_sources_months to 0 so that Forced/Sources are None
         config = self.make_config(read_sources_months=0, read_forced_sources_months=0)
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -305,8 +306,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """Store and retrieve DiaObjects."""
         # don't care about sources.
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -326,8 +327,8 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_storeSources(self) -> None:
         """Store and retrieve DiaSources."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -371,8 +372,8 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_storeForcedSources(self) -> None:
         """Store and retrieve DiaForcedSources."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -405,8 +406,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """Store and retrieve catalog history."""
         # don't care about sources.
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
         visit_time = self.visit_time
 
         region1 = _make_region((1.0, 1.0, -1.0))
@@ -478,8 +479,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """Store and retrieve SSObjects."""
         # don't care about sources.
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         # make catalog with SSObjects
         catalog = makeSSObjectCatalog(100, flags=1)
@@ -503,8 +504,8 @@ class ApdbTest(TestCaseMixin, ABC):
         """Reassign DiaObjects."""
         # don't care about sources.
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         visit_time = self.visit_time
@@ -536,8 +537,8 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_midpointMjdTai_src(self) -> None:
         """Test for time filtering of DiaSources."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         # 2021-01-01 plus 360 days is 2021-12-27
@@ -574,8 +575,8 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_midpointMjdTai_fsrc(self) -> None:
         """Test for time filtering of DiaForcedSources."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         region = _make_region()
         src_time1 = DateTime("2021-01-01T00:00:00", DateTime.TAI)
@@ -611,8 +612,8 @@ class ApdbTest(TestCaseMixin, ABC):
     def test_metadata(self) -> None:
         """Simple test for writing/reading metadata table"""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
         metadata = apdb.metadata
 
         # APDB should write two metadata items with version numbers.
@@ -644,8 +645,8 @@ class ApdbTest(TestCaseMixin, ABC):
         # We expect that schema includes metadata table, drop it.
         with update_schema_yaml(config.schema_file, drop_metadata=True) as schema_file:
             config = self.make_config(schema_file=schema_file)
+            Apdb.makeSchema(config)
             apdb = make_apdb(config)
-            apdb.makeSchema()
             metadata = apdb.metadata
 
             self.assertTrue(metadata.empty())
@@ -695,8 +696,8 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         """
         # Make schema without history tables.
         config = self.make_config(use_insert_id=False)
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
-        apdb.makeSchema()
 
         # Make APDB instance configured for history tables.
         config = self.make_config(use_insert_id=True)
@@ -719,10 +720,10 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
     def test_schemaVersionCheck(self) -> None:
         """Check version number compatibility."""
         config = self.make_config()
+        Apdb.makeSchema(config)
         apdb = make_apdb(config)
 
         self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 1))
-        apdb.makeSchema()
 
         # Claim that schema version is now 99.0.0, must raise an exception.
         with update_schema_yaml(config.schema_file, version="99.0.0") as schema_file:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
+ignore = E133, E226, E228, E704, N802, N803, N806, N812, N815, N816, W503
 exclude =
 	bin,
 	doc/conf.py,

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -106,8 +106,7 @@ class ApdbCassandraMixin:
 
     if TYPE_CHECKING:
         # For mypy.
-        def make_config(self, **kwargs: Any) -> ApdbCassandraConfig:
-            ...
+        def make_config(self, **kwargs: Any) -> ApdbCassandraConfig: ...
 
 
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -48,10 +48,14 @@ class ApdbSQLiteTestCase(ApdbTest, unittest.TestCase):
     dia_object_index = "baseline"
     allow_visit_query = False
 
+    def setUp(self) -> None:
+        self.tempdir = tempfile.mkdtemp()
+        self.db_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
+
     def make_config(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
         kw = {
-            "db_url": "sqlite://",
+            "db_url": self.db_url,
             "schema_file": TEST_SCHEMA,
             "dia_object_index": self.dia_object_index,
             "use_insert_id": self.use_insert_id,


### PR DESCRIPTION
Both implementations now store parts of configuration in metadata
table (if that table exists in the schema) and reload that configuration
when instantiated.