### PR TITLE
DM-43414: Improve dax_apdb configuration and instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config.log
 *.pyc
 *_wrap.cc
 *Lib.py
+bin/*
 
 # Built by sconsUtils
 version.py

--- a/bin.src/SConscript
+++ b/bin.src/SConscript
@@ -1,0 +1,4 @@
+# -*- python -*-
+from lsst.sconsUtils import scripts
+
+scripts.BasicSConscript.shebang()

--- a/bin.src/apdb-cli
+++ b/bin.src/apdb-cli
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+from lsst.dax.apdb.cli import cli
+
+if __name__ == "__main__":
+    cli.cli()

--- a/bin.src/apdb-cli
+++ b/bin.src/apdb-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from lsst.dax.apdb.cli import cli
+from lsst.dax.apdb.cli import apdb_cli
 
 if __name__ == "__main__":
-    cli.cli()
+    apdb_cli.main()

--- a/doc/lsst.dax.apdb/index.rst
+++ b/doc/lsst.dax.apdb/index.rst
@@ -36,3 +36,18 @@ Python API reference
 .. automodapi:: lsst.dax.apdb
    :no-main-docstr:
    :no-inheritance-diagram:
+
+
+Command line tools
+==================
+
+This package provides a command line utility that can be used for some management operations.
+The name of the CLI script is ``apdb-cli`` and it has a number of subcommands:
+
+  - ``create-sql`` is used to create new APDB instances based on SQL relational database technology.
+
+  - ``create-cassandra`` is used to create new APDB instances based on Cassandra storage technology.
+
+  - ``list-index`` dumps the contents of the APDB index file.
+
+Each sub-command provides command line help describing its arguments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,12 @@ max-doc-length = 79
 
 [tool.ruff.pydocstyle]
 convention = "numpy"
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "lsst-utils",
     "numpy",
     "pandas",
+    "pydantic",
     "pyyaml >= 5.1",
     "sqlalchemy"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ convention = "numpy"
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
-    "raise AssertionError",
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",

--- a/python/lsst/dax/apdb/__init__.py
+++ b/python/lsst/dax/apdb/__init__.py
@@ -21,11 +21,8 @@
 
 from .apdb import *
 from .apdbCassandra import *
-from .apdbCassandraSchema import *
 from .apdbMetadata import *
-from .apdbSchema import *
+from .apdbSchema import ApdbTables
 from .apdbSql import *
-from .apdbSqlSchema import *
-from .factory import *
 from .version import *
 from .versionTuple import *

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -38,7 +38,7 @@ from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.sphgeom import Region
 
 from .apdbSchema import ApdbTables
-from .factory import apdb_type, make_apdb
+from .factory import make_apdb
 
 if TYPE_CHECKING:
     from .apdbMetadata import ApdbMetadata
@@ -207,22 +207,6 @@ class Apdb(ABC):
             defined by this implementation.
         """
         raise NotImplementedError()
-
-    @classmethod
-    def makeSchema(cls, config: ApdbConfig, *, drop: bool = False) -> None:
-        """Create or re-create whole database schema.
-
-        Parameters
-        ----------
-        config : `ApdbConfig`
-            Instance of configuration class, the type has to match the type of
-            the actual implementation class of this interface.
-        drop : `bool`
-            If True then drop all tables before creating new ones.
-        """
-        # Dispatch to actual implementation class based on config type.
-        klass = apdb_type(config)
-        klass.makeSchema(config, drop=drop)
 
     @abstractmethod
     def getDiaObjects(self, region: Region) -> pandas.DataFrame:

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -156,15 +156,18 @@ class Apdb(ABC):
         Parameters
         ----------
         uri : `~lsst.resources.ResourcePathExpression`
-            URI pointing to a file with serialized configuration. IF ``uri`` is
-            a string with "label:" prefix then the label name which follows the
-            prefix will be searched in APDB index file whose location is
-            determined by ``DAX_APDB_INDEX_URI`` environment variable.
+            URI or local file path pointing to a file with serialized
+            configuration, or a string with a "label:" prefix. In the latter
+            case, the configuration will be looked up from an APDB index file
+            using the label name that follows the prefix. The APDB index file's
+            location is determined by the ``DAX_APDB_INDEX_URI`` environment
+            variable.
 
         Returns
         -------
         apdb : `apdb`
-            Instance of `Apdb` class.
+            Instance of `Apdb` class, the type of the returned instance is
+            determined by configuration.
         """
         if isinstance(uri, str) and uri.startswith("label:"):
             tag, _, label = uri.partition(":")

--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -171,11 +171,7 @@ class Apdb(ABC):
             index = ApdbIndex()
             # Current format for config files is "pex_config"
             format = "pex_config"
-            try:
-                uri = index.get_apdb_uri(label, format)
-            except KeyError as exc:
-                labels = index.get_known_labels()
-                raise ValueError(f"Unknown index label {uri}, labels known to index: {labels}") from exc
+            uri = index.get_apdb_uri(label, format)
         path = ResourcePath(uri)
         config_str = path.read().decode()
         # Assume that this is ApdbConfig, make_apdb will raise if not.

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -560,12 +560,12 @@ class ApdbCassandra(Apdb):
         if ra_dec_columns is not None:
             config.ra_dec_columns = ra_dec_columns
 
-        cls.makeSchema(config, drop=drop, replication_factor=replication_factor)
+        cls._makeSchema(config, drop=drop, replication_factor=replication_factor)
 
         return config
 
     @classmethod
-    def makeSchema(
+    def _makeSchema(
         cls, config: ApdbConfig, *, drop: bool = False, replication_factor: int | None = None
     ) -> None:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -470,7 +470,7 @@ class ApdbCassandra(Apdb):
         hosts : `list` [`str`]
             List of host names or IP addresses for Cassandra cluster.
         keyspace : `str`
-            NAme of the keyspace for APDB tables.
+            Name of the keyspace for APDB tables.
         schema_file : `str`, optional
             Location of (YAML) configuration file with APDB schema. If not
             specified then default location will be used.
@@ -484,7 +484,7 @@ class ApdbCassandra(Apdb):
         use_insert_id : `bool`, optional
             If True, make additional tables used for replication to PPDB.
         use_insert_id_skips_diaobjects : `bool`, optional
-            If `True` then do not fill regular `ApdbObject` table when
+            If `True` then do not fill regular ``DiaObject`` table when
             ``use_insert_id`` is `True`.
         port : `int`, optional
             Port number to use for Cassandra connections.
@@ -518,7 +518,12 @@ class ApdbCassandra(Apdb):
             Replication factor used when creating new keyspace, if keyspace
             already exists its replication factor is not changed.
         drop : `bool`, optional
-            If `True then drop existing tables before re-creating the schema.
+            If `True` then drop existing tables before re-creating the schema.
+
+        Returns
+        -------
+        config : `ApdbCassandraConfig`
+            Resulting configuration object for a created APDB instance.
         """
         config = ApdbCassandraConfig(
             contact_points=hosts,

--- a/python/lsst/dax/apdb/apdbCassandra.py
+++ b/python/lsst/dax/apdb/apdbCassandra.py
@@ -436,7 +436,138 @@ class ApdbCassandra(Apdb):
         return self._schema.tableSchemas.get(table)
 
     @classmethod
-    def makeSchema(cls, config: ApdbConfig, *, drop: bool = False) -> None:
+    def init_database(
+        cls,
+        hosts: list[str],
+        keyspace: str,
+        *,
+        schema_file: str | None = None,
+        schema_name: str | None = None,
+        read_sources_months: int | None = None,
+        read_forced_sources_months: int | None = None,
+        use_insert_id: bool = False,
+        use_insert_id_skips_diaobjects: bool = False,
+        port: int | None = None,
+        username: str | None = None,
+        prefix: str | None = None,
+        part_pixelization: str | None = None,
+        part_pix_level: int | None = None,
+        time_partition_tables: bool = True,
+        time_partition_start: str | None = None,
+        time_partition_end: str | None = None,
+        read_consistency: str | None = None,
+        write_consistency: str | None = None,
+        read_timeout: int | None = None,
+        write_timeout: int | None = None,
+        ra_dec_columns: list[str] | None = None,
+        replication_factor: int | None = None,
+        drop: bool = False,
+    ) -> ApdbCassandraConfig:
+        """Initialize new APDB instance and make configuration object for it.
+
+        Parameters
+        ----------
+        hosts : `list` [`str`]
+            List of host names or IP addresses for Cassandra cluster.
+        keyspace : `str`
+            NAme of the keyspace for APDB tables.
+        schema_file : `str`, optional
+            Location of (YAML) configuration file with APDB schema. If not
+            specified then default location will be used.
+        schema_name : `str`, optional
+            Name of the schema in YAML configuration file. If not specified
+            then default name will be used.
+        read_sources_months : `int`, optional
+            Number of months of history to read from DiaSource.
+        read_forced_sources_months : `int`, optional
+            Number of months of history to read from DiaForcedSource.
+        use_insert_id : `bool`, optional
+            If True, make additional tables used for replication to PPDB.
+        use_insert_id_skips_diaobjects : `bool`, optional
+            If `True` then do not fill regular `ApdbObject` table when
+            ``use_insert_id`` is `True`.
+        port : `int`, optional
+            Port number to use for Cassandra connections.
+        username : `str`, optional
+            User name for Cassandra connections.
+        prefix : `str`, optional
+            Optional prefix for all table names.
+        part_pixelization : `str`, optional
+            Name of the MOC pixelization used for partitioning.
+        part_pix_level : `int`, optional
+            Pixelization level.
+        time_partition_tables : `bool`, optional
+            Create per-partition tables.
+        time_partition_start : `str`, optional
+            Starting time for per-partition tables, in yyyy-mm-ddThh:mm:ss
+            format, in TAI.
+        time_partition_end : `str`, optional
+            Ending time for per-partition tables, in yyyy-mm-ddThh:mm:ss
+            format, in TAI.
+        read_consistency : `str`, optional
+            Name of the consistency level for read operations.
+        write_consistency : `str`, optional
+            Name of the consistency level for write operations.
+        read_timeout : `int`, optional
+            Read timeout in seconds.
+        write_timeout : `int`, optional
+            Write timeout in seconds.
+        ra_dec_columns : `list` [`str`], optional
+            Names of ra/dec columns in DiaObject table.
+        replication_factor : `int`, optional
+            Replication factor used when creating new keyspace, if keyspace
+            already exists its replication factor is not changed.
+        drop : `bool`, optional
+            If `True then drop existing tables before re-creating the schema.
+        """
+        config = ApdbCassandraConfig(
+            contact_points=hosts,
+            keyspace=keyspace,
+            use_insert_id=use_insert_id,
+            use_insert_id_skips_diaobjects=use_insert_id_skips_diaobjects,
+            time_partition_tables=time_partition_tables,
+        )
+        if schema_file is not None:
+            config.schema_file = schema_file
+        if schema_name is not None:
+            config.schema_name = schema_name
+        if read_sources_months is not None:
+            config.read_sources_months = read_sources_months
+        if read_forced_sources_months is not None:
+            config.read_forced_sources_months = read_forced_sources_months
+        if port is not None:
+            config.port = port
+        if username is not None:
+            config.username = username
+        if prefix is not None:
+            config.prefix = prefix
+        if part_pixelization is not None:
+            config.part_pixelization = part_pixelization
+        if part_pix_level is not None:
+            config.part_pix_level = part_pix_level
+        if time_partition_start is not None:
+            config.time_partition_start = time_partition_start
+        if time_partition_end is not None:
+            config.time_partition_end = time_partition_end
+        if read_consistency is not None:
+            config.read_consistency = read_consistency
+        if write_consistency is not None:
+            config.write_consistency = write_consistency
+        if read_timeout is not None:
+            config.read_timeout = read_timeout
+        if write_timeout is not None:
+            config.write_timeout = write_timeout
+        if ra_dec_columns is not None:
+            config.ra_dec_columns = ra_dec_columns
+
+        cls.makeSchema(config, drop=drop, replication_factor=replication_factor)
+
+        return config
+
+    @classmethod
+    def makeSchema(
+        cls, config: ApdbConfig, *, drop: bool = False, replication_factor: int | None = None
+    ) -> None:
         # docstring is inherited from a base class
 
         if not isinstance(config, ApdbCassandraConfig):
@@ -464,9 +595,9 @@ class ApdbCassandra(Apdb):
                 cls._time_partition_cls(time_partition_start, part_epoch, part_days),
                 cls._time_partition_cls(time_partition_end, part_epoch, part_days) + 1,
             )
-            schema.makeSchema(drop=drop, part_range=part_range)
+            schema.makeSchema(drop=drop, part_range=part_range, replication_factor=replication_factor)
         else:
-            schema.makeSchema(drop=drop)
+            schema.makeSchema(drop=drop, replication_factor=replication_factor)
 
         meta_table_name = ApdbTables.metadata.table_name(config.prefix)
         metadata = ApdbMetadataCassandra(session, meta_table_name, config.keyspace, "read_tuples", "write")

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -406,7 +406,13 @@ class ApdbCassandraSchema(ApdbSchema):
         table_schema = self._table_schema(table_name)
         return [column.name for column in table_schema.primary_key]
 
-    def makeSchema(self, drop: bool = False, part_range: tuple[int, int] | None = None) -> None:
+    def makeSchema(
+        self,
+        *,
+        drop: bool = False,
+        part_range: tuple[int, int] | None = None,
+        replication_factor: int | None = None,
+    ) -> None:
         """Create or re-create all tables.
 
         Parameters
@@ -420,9 +426,13 @@ class ApdbCassandraSchema(ApdbSchema):
             not created.
         """
         # Try to create keyspace if it does not exist
+        if replication_factor is None:
+            replication_factor = 1
         query = (
             f'CREATE KEYSPACE IF NOT EXISTS "{self._keyspace}"'
-            " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}"
+            " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': "
+            f"{replication_factor}"
+            "}"
         )
         self._session.execute(query)
 

--- a/python/lsst/dax/apdb/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/apdbCassandraSchema.py
@@ -418,12 +418,16 @@ class ApdbCassandraSchema(ApdbSchema):
         Parameters
         ----------
         drop : `bool`
-            If True then drop tables before creating new ones.
+            If True then drop tables before creating new ones. Note that
+            only tables are dropped and not the whole keyspace.
         part_range : `tuple` [ `int` ] or `None`
             Start and end partition number for time partitions, end is not
             inclusive. Used to create per-partition DiaObject, DiaSource, and
             DiaForcedSource tables. If `None` then per-partition tables are
             not created.
+        replication_factor : `int`, optional
+            Replication factor used when creating new keyspace, if keyspace
+            already exists its replication factor is not changed.
         """
         # Try to create keyspace if it does not exist
         if replication_factor is None:

--- a/python/lsst/dax/apdb/apdbIndex.py
+++ b/python/lsst/dax/apdb/apdbIndex.py
@@ -1,0 +1,166 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbIndex"]
+
+import io
+import logging
+import os
+from collections.abc import Mapping
+from typing import ClassVar
+
+import yaml
+from lsst.resources import ResourcePath
+from pydantic import TypeAdapter, ValidationError
+
+_LOG = logging.getLogger(__name__)
+
+
+class ApdbIndex:
+    """Index of well-known Apdb instances.
+
+    Parameters
+    ----------
+    index_path : `str`, optional
+        Path to the index configuration file, if not provided then the value
+        of ``DAX_APDB_INDEX_URI`` environment variable is used to locate
+        configuration file.
+
+    The index is configured from a simple YAML file whose location is
+    determined from ``DAX_APDB_INDEX_URI`` environment variable. The content
+    of the index file is a mapping of the labels to URIs in YAML format, e.g.:
+
+    .. code-block:: yaml
+
+       dev: "/path/to/config-file.yaml"
+       "prod/pex_config": "s3://bucket/apdb-prod.py"
+       "prod/yaml": "s3://bucket/apdb-prod.yaml"
+
+    """
+
+    index_env_var: ClassVar[str] = "DAX_APDB_INDEX_URI"
+    """The name of the environment variable containing the URI of the index
+    configuration file.
+    """
+
+    _cache: Mapping[str, str] | None = None
+    """Contents of the index file cached in memory."""
+
+    def __init__(self, index_path: str | None = None):
+        self._index_path = index_path
+
+    @classmethod
+    def _read_index(cls, index_path: str | None = None) -> Mapping[str, str]:
+        if index_path is None:
+            index_path = os.getenv(cls.index_env_var)
+            if index_path is None:
+                raise RuntimeError(
+                    f"No repository index defined, environment variable {cls.index_env_var} is not set."
+                )
+        index_uri = ResourcePath(index_path)
+        _LOG.debug("Opening YAML index file: %s", index_uri.geturl())
+        content = index_uri.read()
+        # Use a stream so we can name it
+        stream = io.BytesIO(content)
+        if index_data := yaml.load(stream, Loader=yaml.SafeLoader):
+            try:
+                return TypeAdapter(dict[str, str]).validate_python(index_data)
+            except ValidationError as e:
+                raise TypeError(f"Repository index {index_uri.geturl()} not in expected format") from e
+        return {}
+
+    def get_apdb_uri(self, label: str, format: str | None = None) -> ResourcePath:
+        """Return URI for APDB configuration file given its label.
+
+        Parameters
+        ----------
+        label : `str`
+            Label of APDB instance.
+        format : `str`
+            Format of the APDB configuration file, arbitrary string. This can
+            be used to support an expected migration from pex_config to YAML
+            configuration for APDB, code that uses pex_config could provide
+            "pex_config" for ``format``. The actual key in the index is
+            either a slash-separated label and format, or, if that is missing,
+            just a label.
+
+        Returns
+        -------
+        uri : `~lsst.resources.ResourcePath`
+            URI for the configuration file for APDB instance.
+
+        Raises
+        ------
+        FileNotFoundError
+            Raised if an index is defined in the environment but it
+            can not be found.
+        KeyError
+            Raised if the label is not found in the index.
+        TypeError
+            Raised if the format of the index file is incorrect.
+        """
+        if self._cache is None:
+            self._cache = self._read_index(self._index_path)
+        labels: list[str] = [label]
+        if format:
+            labels.insert(0, f"{label}/{format}")
+        for label in labels:
+            if (uri_str := self._cache.get(label)) is not None:
+                return ResourcePath(uri_str)
+        if len(labels) == 1:
+            raise KeyError(f"Label {labels[0]} is not defined in index file.")
+        else:
+            labels_str = ", ".join(labels)
+            raise KeyError(f"None of labels {labels_str} is defined in index file.")
+
+    def get_known_labels(self) -> set[str]:
+        """Retrieve the set of labels defined in index.
+
+        Returns
+        -------
+        repos : `set` of `str`
+            All known labels. Can be empty if no index can be found.
+        """
+        if self._cache is not None:
+            return set(self._cache)
+        # If have not read yet then try to read but ignore any errors.
+        try:
+            return set(self._read_index(self._index_path))
+        except Exception:
+            return set()
+
+    def get_entries(self) -> Mapping[str, str]:
+        """Retrieve all entries defined in index.
+
+        Returns
+        -------
+        entries : `~collections.abc.Mapping` [`str`, `str`]
+            All known entries. Can be empty if no index can be found.
+        """
+        if self._cache is not None:
+            return self._cache
+        # If have not read yet then try to read but ignore any errors.
+        try:
+            return self._read_index(self._index_path)
+        except Exception:
+            return {}

--- a/python/lsst/dax/apdb/apdbIndex.py
+++ b/python/lsst/dax/apdb/apdbIndex.py
@@ -56,7 +56,7 @@ class ApdbIndex:
        "prod/pex_config": "s3://bucket/apdb-prod.py"
        "prod/yaml": "s3://bucket/apdb-prod.yaml"
 
-    The labels in the index file consists of the label name and an option
+    The labels in the index file consists of the label name and an optional
     format name separated from label by slash. `get_apdb_uri` method can
     use its ``format`` argument to return either a format-specific
     configuration or a label-only configuration if format-specific is not
@@ -174,7 +174,7 @@ class ApdbIndex:
         Returns
         -------
         entries : `~collections.abc.Mapping` [`str`, `str`]
-            All known entries. Can be empty if no index can be found.
+            All known index entries.
 
         Raises
         ------

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -333,6 +333,89 @@ class ApdbSql(Apdb):
         # Docstring inherited from base class.
         return VERSION
 
+    @classmethod
+    def init_database(
+        cls,
+        db_url: str,
+        *,
+        schema_file: str | None = None,
+        schema_name: str | None = None,
+        read_sources_months: int | None = None,
+        read_forced_sources_months: int | None = None,
+        use_insert_id: bool = False,
+        connection_timeout: int | None = None,
+        dia_object_index: str | None = None,
+        htm_level: int | None = None,
+        htm_index_column: str | None = None,
+        ra_dec_columns: list[str] | None = None,
+        prefix: str | None = None,
+        namespace: str | None = None,
+        drop: bool = False,
+    ) -> ApdbSqlConfig:
+        """Initialize new APDB instance and make configuration object for it.
+
+        Parameters
+        ----------
+        db_url : `str`
+            SQLAlchemy database URL.
+        schema_file : `str`, optional
+            Location of (YAML) configuration file with APDB schema. If not
+            specified then default location will be used.
+        schema_name : str | None
+            Name of the schema in YAML configuration file. If not specified
+            then default name will be used.
+        read_sources_months : `int`, optional
+            Number of months of history to read from DiaSource.
+        read_forced_sources_months : `int`, optional
+            Number of months of history to read from DiaForcedSource.
+        use_insert_id : `bool`
+            If True, make additional tables used for replication to PPDB.
+        connection_timeout : `int`, optional
+            Database connection timeout in seconds.
+        dia_object_index : `str`, optional
+            Indexing mode for DiaObject table.
+        htm_level : `int`, optional
+            HTM indexing level.
+        htm_index_column : `str`, optional
+            Name of a HTM index column for DiaObject and DiaSource tables.
+        ra_dec_columns : `list` [`str`], optional
+            Names of ra/dec columns in DiaObject table.
+        prefix : `str`, optional
+            Optional prefix for all table names.
+        namespace : `str`, optional
+            Name of the database schema for all APDB tables. If not specified
+            then default schema is used.
+        drop : `bool`, optional
+            If `True then drop existing tables before re-creating the schema.
+        """
+        config = ApdbSqlConfig(db_url=db_url, use_insert_id=use_insert_id)
+        if schema_file is not None:
+            config.schema_file = schema_file
+        if schema_name is not None:
+            config.schema_name = schema_name
+        if read_sources_months is not None:
+            config.read_sources_months = read_sources_months
+        if read_forced_sources_months is not None:
+            config.read_forced_sources_months = read_forced_sources_months
+        if connection_timeout is not None:
+            config.connection_timeout = connection_timeout
+        if dia_object_index is not None:
+            config.dia_object_index = dia_object_index
+        if htm_level is not None:
+            config.htm_level = htm_level
+        if htm_index_column is not None:
+            config.htm_index_column = htm_index_column
+        if ra_dec_columns is not None:
+            config.ra_dec_columns = ra_dec_columns
+        if prefix is not None:
+            config.prefix = prefix
+        if namespace is not None:
+            config.namespace = namespace
+
+        cls.makeSchema(config, drop=drop)
+
+        return config
+
     def apdbSchemaVersion(self) -> VersionTuple:
         # Docstring inherited from base class.
         return self._schema.schemaVersion()

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -412,7 +412,7 @@ class ApdbSql(Apdb):
         if namespace is not None:
             config.namespace = namespace
 
-        cls.makeSchema(config, drop=drop)
+        cls._makeSchema(config, drop=drop)
 
         return config
 
@@ -449,7 +449,7 @@ class ApdbSql(Apdb):
         return self._schema.tableSchemas.get(table)
 
     @classmethod
-    def makeSchema(cls, config: ApdbConfig, drop: bool = False) -> None:
+    def _makeSchema(cls, config: ApdbConfig, drop: bool = False) -> None:
         # docstring is inherited from a base class
 
         if not isinstance(config, ApdbSqlConfig):

--- a/python/lsst/dax/apdb/apdbSql.py
+++ b/python/lsst/dax/apdb/apdbSql.py
@@ -386,7 +386,12 @@ class ApdbSql(Apdb):
             Name of the database schema for all APDB tables. If not specified
             then default schema is used.
         drop : `bool`, optional
-            If `True then drop existing tables before re-creating the schema.
+            If `True` then drop existing tables before re-creating the schema.
+
+        Returns
+        -------
+        config : `ApdbSqlConfig`
+            Resulting configuration object for a created APDB instance.
         """
         config = ApdbSqlConfig(db_url=db_url, use_insert_id=use_insert_id)
         if schema_file is not None:

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["cli"]
+__all__ = ["main"]
 
 import argparse
 from collections.abc import Sequence
@@ -31,7 +31,7 @@ from . import options
 from .logging_cli import LoggingCli
 
 
-def cli(args: Sequence[str] | None = None) -> None:
+def main(args: Sequence[str] | None = None) -> None:
     """APDB command line tools."""
     parser = argparse.ArgumentParser(description="APDB command line tools")
     log_cli = LoggingCli(parser)

--- a/python/lsst/dax/apdb/cli/cli.py
+++ b/python/lsst/dax/apdb/cli/cli.py
@@ -31,7 +31,7 @@ from . import options
 from .logging_cli import LoggingCli
 
 
-def cli(args: Sequence | None = None) -> None:
+def cli(args: Sequence[str] | None = None) -> None:
     """APDB command line tools."""
     parser = argparse.ArgumentParser(description="APDB command line tools")
     log_cli = LoggingCli(parser)

--- a/python/lsst/dax/apdb/cli/cli.py
+++ b/python/lsst/dax/apdb/cli/cli.py
@@ -39,6 +39,7 @@ def cli(args: Sequence | None = None) -> None:
     subparsers = parser.add_subparsers(title="available subcommands", required=True)
     _create_sql_subcommand(subparsers)
     _create_cassandra_subcommand(subparsers)
+    _list_index_subcommand(subparsers)
 
     parsed_args = parser.parse_args(args)
     log_cli.process_args(parsed_args)
@@ -74,3 +75,11 @@ def _create_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None
         "--drop", help="If True then drop existing tables.", default=False, action="store_true"
     )
     parser.set_defaults(method=scripts.create_cassandra)
+
+
+def _list_index_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("list-index", help="List contents of APDB index file.")
+    parser.add_argument(
+        "index_path", help="Location of index file, if missing then $DAX_APDB_INDEX_URI is used.", nargs="?"
+    )
+    parser.set_defaults(method=scripts.list_index)

--- a/python/lsst/dax/apdb/cli/cli.py
+++ b/python/lsst/dax/apdb/cli/cli.py
@@ -1,0 +1,76 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["cli"]
+
+import argparse
+from collections.abc import Sequence
+
+from .. import scripts
+from . import options
+from .logging_cli import LoggingCli
+
+
+def cli(args: Sequence | None = None) -> None:
+    """APDB command line tools."""
+    parser = argparse.ArgumentParser(description="APDB command line tools")
+    log_cli = LoggingCli(parser)
+
+    subparsers = parser.add_subparsers(title="available subcommands", required=True)
+    _create_sql_subcommand(subparsers)
+    _create_cassandra_subcommand(subparsers)
+
+    parsed_args = parser.parse_args(args)
+    log_cli.process_args(parsed_args)
+
+    kwargs = vars(parsed_args)
+    # Strip keywords not understood by scripts.
+    method = kwargs.pop("method")
+    method(**kwargs)
+
+
+def _create_sql_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("create-sql", help="Create new APDB instance in SQL database.")
+    parser.add_argument("db_url", help="Database URL in SQLAlchemy format for APDB instance.")
+    parser.add_argument("config_path", help="Name of the new configuration file for created APDB instance.")
+    options.common_apdb_options(parser)
+    options.sql_config_options(parser)
+    parser.add_argument(
+        "--drop", help="If True then drop existing tables.", default=False, action="store_true"
+    )
+    parser.set_defaults(method=scripts.create_sql)
+
+
+def _create_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("create-cassandra", help="Create new APDB instance in Cassandra cluster.")
+    parser.add_argument("host", help="One or more host names for Cassandra cluster.", nargs="+")
+    parser.add_argument(
+        "keyspace", help="Cassandra keyspace name for APDB tables, will be created if does not exist."
+    )
+    parser.add_argument("config_path", help="Name of the new configuration file for created APDB instance.")
+    options.common_apdb_options(parser)
+    options.cassandra_config_options(parser)
+    parser.add_argument(
+        "--drop", help="If True then drop existing tables.", default=False, action="store_true"
+    )
+    parser.set_defaults(method=scripts.create_cassandra)

--- a/python/lsst/dax/apdb/cli/logging_cli.py
+++ b/python/lsst/dax/apdb/cli/logging_cli.py
@@ -1,0 +1,73 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["LoggingCli"]
+
+import argparse
+import logging
+
+_log_format = "%(asctime)s %(levelname)s %(name)s - %(message)s"
+
+
+class LoggingCli:
+    """Class that handles CLI logging options and logging configuration.
+
+    Parameters
+    ----------
+    parser : `argparse.ArgumentParser`
+        Parser for which to define logging options.
+    """
+
+    def __init__(self, parser: argparse.ArgumentParser):
+        self._parser = parser
+        parser.add_argument(
+            "-l",
+            "--log-level",
+            dest="log_level",
+            action="append",
+            metavar="LEVEL|LOGGER=LEVEL[,...]",
+            help="Global or per-logger logging level, comma-separated and can be specified multiple times",
+            default=[],
+        )
+
+    def process_args(self, args: argparse.Namespace) -> None:
+        """Configure Python logging based on command line options."""
+        global_level = logging.INFO
+        logger_levels: dict[str, int] = {}
+        for level_str in args.log_level:
+            for spec in level_str.split(","):
+                logger_name, sep, level_name = spec.rpartition("=")
+                level = logging.getLevelNamesMapping().get(level_name.upper())
+                if level is None:
+                    self._parser.error(f"Unknown logging level in {level_str!r}")
+                if logger_name:
+                    logger_levels[logger_name] = level
+                else:
+                    global_level = level
+
+        logging.basicConfig(level=global_level, format=_log_format)
+        for logger_name, level in logger_levels.items():
+            logging.getLogger(logger_name).setLevel(level)
+
+        # Remove namespace attribute.
+        del args.log_level

--- a/python/lsst/dax/apdb/cli/logging_cli.py
+++ b/python/lsst/dax/apdb/cli/logging_cli.py
@@ -59,7 +59,7 @@ class LoggingCli:
                 logger_name, sep, level_name = spec.rpartition("=")
                 level = logging.getLevelNamesMapping().get(level_name.upper())
                 if level is None:
-                    self._parser.error(f"Unknown logging level in {level_str!r}")
+                    self._parser.error(f"Unknown logging level {level_name!r} in {level_str!r}")
                 if logger_name:
                     logger_levels[logger_name] = level
                 else:
@@ -69,5 +69,6 @@ class LoggingCli:
         for logger_name, level in logger_levels.items():
             logging.getLogger(logger_name).setLevel(level)
 
-        # Remove namespace attribute.
+        # We want to remove `log_level` so that namespace can be converted to
+        # a dict and passed as kwargs to scripts.
         del args.log_level

--- a/python/lsst/dax/apdb/cli/options.py
+++ b/python/lsst/dax/apdb/cli/options.py
@@ -1,0 +1,114 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["cassandra_config_options", "common_apdb_options", "sql_config_options"]
+
+import argparse
+from typing import TYPE_CHECKING, Any
+
+from ..apdb import ApdbConfig
+from ..apdbCassandra import ApdbCassandraConfig
+from ..apdbSql import ApdbSqlConfig
+
+if TYPE_CHECKING:
+    from lsst.pex.config import Field
+
+
+def _option_from_pex_field(
+    group: argparse._ArgumentGroup,
+    field: Field,
+    *,
+    name: str | None = None,
+    help: str | None = None,
+    **kwargs: Any,
+) -> None:
+    """Convert pex_config Field to argparse argument definition."""
+    if name is None:
+        name = "--" + field.name.replace("_", "-")
+    if help is None:
+        help = field.doc
+    group.add_argument(name, dest=field.name, help=help, **kwargs)
+
+
+# Options for fields in ApdbConfig.
+def common_apdb_options(parser: argparse.ArgumentParser) -> None:
+    """Define common configuration options."""
+    group = parser.add_argument_group("common APDB options")
+    _option_from_pex_field(group, ApdbConfig.schema_file, metavar="URL")
+    _option_from_pex_field(group, ApdbConfig.schema_name)
+    _option_from_pex_field(group, ApdbConfig.read_sources_months, type=int)
+    _option_from_pex_field(group, ApdbConfig.read_forced_sources_months, type=int)
+    _option_from_pex_field(group, ApdbConfig.use_insert_id, action="store_true", default=False)
+
+
+# Options for fields in ApdbSqlConfig, db_url is not included.
+def sql_config_options(parser: argparse.ArgumentParser) -> None:
+    """Define SQL backend configuration options."""
+    group = parser.add_argument_group("SQL backend options")
+    _option_from_pex_field(group, ApdbSqlConfig.namespace, metavar="IDENTIFIER")
+    _option_from_pex_field(group, ApdbSqlConfig.connection_timeout, type=int, metavar="SECONDS")
+    _option_from_pex_field(
+        group, ApdbSqlConfig.dia_object_index, choices=["baseline", "pix_id_iov", "last_object_table"]
+    )
+    _option_from_pex_field(group, ApdbSqlConfig.htm_level, type=int)
+    _option_from_pex_field(group, ApdbSqlConfig.htm_index_column)
+    _option_from_pex_field(
+        group,
+        ApdbSqlConfig.ra_dec_columns,
+        help="Names of ra/dec columns in DiaObject table, comma-separated.",
+        metavar="RA_COLUMN,DEC_COLUMN",
+    )
+    _option_from_pex_field(group, ApdbSqlConfig.prefix)
+
+
+# Options for fields in ApdbCassandraConfig, contact_points is not included.
+def cassandra_config_options(parser: argparse.ArgumentParser) -> None:
+    """Define Cassandra backend configuration options."""
+    group = parser.add_argument_group("Cassandra backend options")
+    _option_from_pex_field(group, ApdbCassandraConfig.use_insert_id_skips_diaobjects, action="store_true")
+    _option_from_pex_field(group, ApdbCassandraConfig.port, type=int, metavar="PORT")
+    _option_from_pex_field(group, ApdbCassandraConfig.username, metavar="USER")
+    _option_from_pex_field(group, ApdbCassandraConfig.prefix)
+    group.add_argument(
+        "--replication-factor", help="Replication factor used when creating new keyspace.", type=int
+    )
+    _option_from_pex_field(
+        group, ApdbCassandraConfig.read_consistency, choices=["ONE", "TWO", "THREE", "QUORUM", "ALL"]
+    )
+    _option_from_pex_field(
+        group, ApdbCassandraConfig.write_consistency, choices=["ONE", "TWO", "THREE", "QUORUM", "ALL"]
+    )
+    _option_from_pex_field(group, ApdbCassandraConfig.read_timeout, type=int, metavar="SECONDS")
+    _option_from_pex_field(group, ApdbCassandraConfig.write_timeout, type=int, metavar="SECONDS")
+    _option_from_pex_field(
+        group,
+        ApdbCassandraConfig.ra_dec_columns,
+        help="Names of ra/dec columns in DiaObject table, comma-separated.",
+        metavar="RA_COLUMN,DEC_COLUMN",
+    )
+    group = parser.add_argument_group("Cassandra partitioning options")
+    _option_from_pex_field(group, ApdbCassandraConfig.part_pixelization, metavar="NAME")
+    _option_from_pex_field(group, ApdbCassandraConfig.part_pix_level, type=int, metavar="LEVEL")
+    _option_from_pex_field(group, ApdbCassandraConfig.time_partition_tables, action="store_true")
+    _option_from_pex_field(group, ApdbCassandraConfig.time_partition_start, metavar="TIME")
+    _option_from_pex_field(group, ApdbCassandraConfig.time_partition_end, metavar="TIME")

--- a/python/lsst/dax/apdb/factory.py
+++ b/python/lsst/dax/apdb/factory.py
@@ -23,9 +23,12 @@ from __future__ import annotations
 
 __all__ = ["apdb_type", "make_apdb"]
 
-from .apdb import Apdb, ApdbConfig
-from .apdbCassandra import ApdbCassandra, ApdbCassandraConfig
-from .apdbSql import ApdbSql, ApdbSqlConfig
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .apdb import Apdb, ApdbConfig
+    from .apdbCassandra import ApdbCassandra
+    from .apdbSql import ApdbSql
 
 
 def apdb_type(config: ApdbConfig) -> type[ApdbSql | ApdbCassandra]:
@@ -46,6 +49,9 @@ def apdb_type(config: ApdbConfig) -> type[ApdbSql | ApdbCassandra]:
     TypeError
         Raised if type of ``config`` does not match any known types.
     """
+    from .apdbCassandra import ApdbCassandra, ApdbCassandraConfig
+    from .apdbSql import ApdbSql, ApdbSqlConfig
+
     if type(config) is ApdbSqlConfig:
         return ApdbSql
     elif type(config) is ApdbCassandraConfig:
@@ -71,6 +77,9 @@ def make_apdb(config: ApdbConfig) -> Apdb:
     TypeError
         Raised if type of ``config`` does not match any known types.
     """
+    from .apdbCassandra import ApdbCassandra, ApdbCassandraConfig
+    from .apdbSql import ApdbSql, ApdbSqlConfig
+
     if type(config) is ApdbSqlConfig:
         return ApdbSql(config)
     elif type(config) is ApdbCassandraConfig:

--- a/python/lsst/dax/apdb/scripts/__init__.py
+++ b/python/lsst/dax/apdb/scripts/__init__.py
@@ -1,0 +1,23 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .create_cassandra import create_cassandra
+from .create_sql import create_sql

--- a/python/lsst/dax/apdb/scripts/create_cassandra.py
+++ b/python/lsst/dax/apdb/scripts/create_cassandra.py
@@ -1,0 +1,48 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["create_cassandra"]
+
+from typing import Any
+
+from ..apdbCassandra import ApdbCassandra
+
+
+def create_cassandra(config_path: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
+    """Create new APDB instance in Cassandra cluster.
+
+    Parameters
+    ----------
+    config_path : `str`
+        Name of the file to write APDB configuration.
+    ra_dec_columns : `str` or `None`
+        Comma-separated list of names for ra/dec columns in DiaObject table.
+    **kwargs
+        Keyword arguments passed to `ApdbCassandra.init_database` method.
+    """
+    ra_dec_list: list[str] | None = None
+    if ra_dec_columns:
+        ra_dec_list = ra_dec_columns.split(",")
+    kwargs["hosts"] = kwargs.pop("host")
+    config = ApdbCassandra.init_database(ra_dec_columns=ra_dec_list, **kwargs)
+    config.save(config_path)

--- a/python/lsst/dax/apdb/scripts/create_sql.py
+++ b/python/lsst/dax/apdb/scripts/create_sql.py
@@ -1,0 +1,47 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["create_sql"]
+
+from typing import Any
+
+from ..apdbSql import ApdbSql
+
+
+def create_sql(config_path: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
+    """Create new APDB instance in SQL database.
+
+    Parameters
+    ----------
+    config_path : `str`
+        Name of the file to write APDB configuration.
+    ra_dec_columns : `str` or `None`
+        Comma-separated list of names for ra/dec columns in DiaObject table.
+    **kwargs
+        Keyword arguments passed to `ApdbSql.init_database` method.
+    """
+    ra_dec_list: list[str] | None = None
+    if ra_dec_columns:
+        ra_dec_list = ra_dec_columns.split(",")
+    config = ApdbSql.init_database(ra_dec_columns=ra_dec_list, **kwargs)
+    config.save(config_path)

--- a/python/lsst/dax/apdb/scripts/list_index.py
+++ b/python/lsst/dax/apdb/scripts/list_index.py
@@ -19,6 +19,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .create_cassandra import create_cassandra
-from .create_sql import create_sql
-from .list_index import list_index
+from __future__ import annotations
+
+__all__ = ["list_index"]
+
+from ..apdbIndex import ApdbIndex
+
+
+def list_index(index_path: str | None) -> None:
+    """List contents of APDB index file.
+
+    Parameters
+    ----------
+    index_path : `str`, optional
+        Location of index file, if missing then $DAX_APDB_INDEX_URI is used.
+    """
+    index = ApdbIndex(index_path)
+    entries = index.get_entries()
+    for label, uri in sorted(entries.items()):
+        print(f"{label}: {uri}")

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -43,7 +43,6 @@ from lsst.dax.apdb import (
     ApdbTables,
     IncompatibleVersionError,
     VersionTuple,
-    make_apdb,
 )
 from lsst.sphgeom import Angle, Circle, Region, UnitVector3d
 
@@ -190,7 +189,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test for making APDB schema."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObjectLast))
@@ -207,7 +206,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # use non-zero months for Forced/Source fetching
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -266,7 +265,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # set read_sources_months to 0 so that Forced/Sources are None
         config = self.make_config(read_sources_months=0, read_forced_sources_months=0)
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -307,7 +306,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # don't care about sources.
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -328,7 +327,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test calling storeObject when there are no objects: see DM-43270."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         region = _make_region()
         visit_time = self.visit_time
         # make catalog with no Objects
@@ -342,7 +341,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Store and retrieve DiaSources."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -387,7 +386,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Store and retrieve DiaForcedSources."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -421,7 +420,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # don't care about sources.
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         visit_time = self.visit_time
 
         region1 = _make_region((1.0, 1.0, -1.0))
@@ -494,7 +493,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # don't care about sources.
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         # make catalog with SSObjects
         catalog = makeSSObjectCatalog(100, flags=1)
@@ -519,7 +518,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # don't care about sources.
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         visit_time = self.visit_time
@@ -552,7 +551,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test for time filtering of DiaSources."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         # 2021-01-01 plus 360 days is 2021-12-27
@@ -590,7 +589,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test for time filtering of DiaForcedSources."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         region = _make_region()
         src_time1 = astropy.time.Time("2021-01-01T00:00:00", format="isot", scale="tai")
@@ -627,7 +626,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Simple test for writing/reading metadata table"""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         metadata = apdb.metadata
 
         # APDB should write two metadata items with version numbers and a
@@ -661,7 +660,7 @@ class ApdbTest(TestCaseMixin, ABC):
         with update_schema_yaml(config.schema_file, drop_metadata=True) as schema_file:
             config_nometa = self.make_config(schema_file=schema_file)
             Apdb.makeSchema(config_nometa)
-            apdb = make_apdb(config_nometa)
+            apdb = Apdb.from_config(config_nometa)
             metadata = apdb.metadata
 
             self.assertTrue(metadata.empty())
@@ -676,7 +675,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # database is missing it. Database was initialized inside above context
         # without metadata table, here we use schema config which includes
         # metadata table.
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         metadata = apdb.metadata
         self.assertTrue(metadata.empty())
 
@@ -684,17 +683,17 @@ class ApdbTest(TestCaseMixin, ABC):
         """Check version number handling for reading schema from YAML."""
         config = self.make_config()
         default_schema = config.schema_file
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 1))
 
         with update_schema_yaml(default_schema, version="") as schema_file:
             config = self.make_config(schema_file=schema_file)
-            apdb = make_apdb(config)
+            apdb = Apdb.from_config(config)
             self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 0))
 
         with update_schema_yaml(default_schema, version="99.0.0") as schema_file:
             config = self.make_config(schema_file=schema_file)
-            apdb = make_apdb(config)
+            apdb = Apdb.from_config(config)
             self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(99, 0, 0))
 
     def test_config_freeze(self) -> None:
@@ -705,7 +704,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # `use_insert_id` is the only parameter that is frozen in all
         # implementations.
         config.use_insert_id = not self.use_insert_id
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
         frozen_config = apdb.config  # type: ignore[attr-defined]
         self.assertEqual(frozen_config.use_insert_id, self.use_insert_id)
 
@@ -732,11 +731,11 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         # Make schema without history tables.
         config = self.make_config(use_insert_id=False)
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         # Make APDB instance configured for history tables.
         config = self.make_config(use_insert_id=True)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         # Try to insert something, should work OK.
         region = _make_region()
@@ -756,7 +755,7 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         """Check version number compatibility."""
         config = self.make_config()
         Apdb.makeSchema(config)
-        apdb = make_apdb(config)
+        apdb = Apdb.from_config(config)
 
         self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 1))
 
@@ -764,4 +763,4 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         with update_schema_yaml(config.schema_file, version="99.0.0") as schema_file:
             config = self.make_config(schema_file=schema_file)
             with self.assertRaises(IncompatibleVersionError):
-                apdb = make_apdb(config)
+                apdb = Apdb.from_config(config)

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -25,6 +25,7 @@ __all__ = ["ApdbSchemaUpdateTest", "ApdbTest", "update_schema_yaml"]
 
 import contextlib
 import os
+import tempfile
 import unittest
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -192,6 +193,17 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test for making APDB schema."""
         config = self.make_instance()
         apdb = Apdb.from_config(config)
+
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObjectLast))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaSource))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaForcedSource))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.metadata))
+
+        # Test from_uri factory method with the same config.
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            config.save(tmpfile.name)
+            apdb = Apdb.from_uri(tmpfile.name)
 
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObjectLast))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ pandas
 pydantic
 pyyaml >= 5.1
 sqlalchemy
-git+https://github.com/lsst/felis@main#egg=lsst-felis
-git+https://github.com/lsst/pex_config@main#egg=lsst-pex-config
-git+https://github.com/lsst/sphgeom@main#egg=lsst-sphgeom
-git+https://github.com/lsst/utils@main#egg=lsst-utils
+lsst-utils @ git+https://github.com/lsst/utils@main
+lsst-resources[s3] @ git+https://github.com/lsst/resources@main
+lsst-sphgeom @ git+https://github.com/lsst/sphgeom@main
+lsst-felis @ git+https://github.com/lsst/felis@main
+lsst-pex-config @ git+https://github.com/lsst/pex_config@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 astropy
 numpy
 pandas
+pydantic
 pyyaml >= 5.1
 sqlalchemy
 git+https://github.com/lsst/felis@main#egg=lsst-felis

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -117,7 +117,7 @@ class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
 
     def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
-        kw = {
+        kw: dict[str, Any] = {
             "hosts": [self.cluster_host],
             "keyspace": self.keyspace,
             "schema_file": TEST_SCHEMA,
@@ -129,7 +129,7 @@ class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
         if self.time_partition_end:
             kw["time_partition_end"] = self.time_partition_end
         kw.update(kwargs)
-        return ApdbCassandra.init_database(**kw)  # type: ignore[arg-type]
+        return ApdbCassandra.init_database(**kw)
 
     def getDiaObjects_table(self) -> ApdbTables:
         """Return type of table returned from getDiaObjects method."""

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -30,7 +30,7 @@ import unittest
 from typing import Any
 
 import lsst.utils.tests
-from lsst.dax.apdb import ApdbConfig, ApdbSqlConfig, ApdbTables
+from lsst.dax.apdb import ApdbConfig, ApdbSql, ApdbTables
 from lsst.dax.apdb.tests import ApdbSchemaUpdateTest, ApdbTest
 
 try:
@@ -47,12 +47,13 @@ class ApdbSQLiteTestCase(ApdbTest, unittest.TestCase):
     fsrc_requires_id_list = True
     dia_object_index = "baseline"
     allow_visit_query = False
+    schema_path = TEST_SCHEMA
 
     def setUp(self) -> None:
         self.tempdir = tempfile.mkdtemp()
         self.db_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
 
-    def make_config(self, **kwargs: Any) -> ApdbConfig:
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
         kw = {
             "db_url": self.db_url,
@@ -61,7 +62,7 @@ class ApdbSQLiteTestCase(ApdbTest, unittest.TestCase):
             "use_insert_id": self.use_insert_id,
         }
         kw.update(kwargs)
-        return ApdbSqlConfig(**kw)
+        return ApdbSql.init_database(**kw)  # type: ignore[arg-type]
 
     def getDiaObjects_table(self) -> ApdbTables:
         """Return type of table returned from getDiaObjects method."""
@@ -103,6 +104,7 @@ class ApdbPostgresTestCase(ApdbTest, unittest.TestCase):
     postgresql: Any
     use_insert_id = True
     allow_visit_query = False
+    schema_path = TEST_SCHEMA
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -124,7 +126,7 @@ class ApdbPostgresTestCase(ApdbTest, unittest.TestCase):
     def tearDown(self) -> None:
         self.server = self.postgresql()
 
-    def make_config(self, **kwargs: Any) -> ApdbConfig:
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
         kw = {
             "db_url": self.server.url(),
@@ -133,7 +135,7 @@ class ApdbPostgresTestCase(ApdbTest, unittest.TestCase):
             "use_insert_id": self.use_insert_id,
         }
         kw.update(kwargs)
-        return ApdbSqlConfig(**kw)
+        return ApdbSql.init_database(**kw)
 
     def getDiaObjects_table(self) -> ApdbTables:
         """Return type of table returned from getDiaObjects method."""
@@ -147,9 +149,9 @@ class ApdbPostgresNamespaceTestCase(ApdbPostgresTestCase):
     # use mixed case to trigger quoting
     namespace = "ApdbSchema"
 
-    def make_config(self, **kwargs: Any) -> ApdbConfig:
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
-        return super().make_config(namespace=self.namespace, **kwargs)
+        return super().make_instance(namespace=self.namespace, **kwargs)
 
 
 class ApdbSchemaUpdateSQLiteTestCase(ApdbSchemaUpdateTest, unittest.TestCase):
@@ -162,14 +164,14 @@ class ApdbSchemaUpdateSQLiteTestCase(ApdbSchemaUpdateTest, unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
-    def make_config(self, **kwargs: Any) -> ApdbConfig:
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""
         kw = {
             "db_url": self.db_url,
             "schema_file": TEST_SCHEMA,
         }
         kw.update(kwargs)
-        return ApdbSqlConfig(**kw)
+        return ApdbSql.init_database(**kw)  # type: ignore[arg-type]
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,58 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for apdb-cli commands."""
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from lsst.dax.apdb import Apdb
+from lsst.dax.apdb.cli import cli
+
+TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
+
+
+class CreateSqlTestCase(unittest.TestCase):
+    """A test case for apdb-cli create-sql command."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.mkdtemp()
+        self.db_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
+        self.config_path = f"{self.tempdir}/apdb-sql.py"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_create_sql(self) -> None:
+        """Create SQLite APDB instance and config file for it."""
+        args = ["create-sql", "--schema-file", TEST_SCHEMA, self.db_url, self.config_path]
+        cli.cli(args)
+        self.assertTrue(os.path.exists(f"{self.tempdir}/apdb.sqlite3"))
+        self.assertTrue(os.path.exists(self.config_path))
+
+        # Make Apdb instance from this new config.
+        Apdb.from_uri(self.config_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ import tempfile
 import unittest
 
 from lsst.dax.apdb import Apdb
-from lsst.dax.apdb.cli import cli
+from lsst.dax.apdb.cli import apdb_cli
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
 
@@ -46,7 +46,7 @@ class CreateSqlTestCase(unittest.TestCase):
     def test_create_sql(self) -> None:
         """Create SQLite APDB instance and config file for it."""
         args = ["create-sql", "--schema-file", TEST_SCHEMA, self.db_url, self.config_path]
-        cli.cli(args)
+        apdb_cli.main(args)
         self.assertTrue(os.path.exists(f"{self.tempdir}/apdb.sqlite3"))
         self.assertTrue(os.path.exists(self.config_path))
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,118 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from lsst.dax.apdb.apdbIndex import ApdbIndex
+from lsst.resources import ResourcePath
+
+VALID_INDEX = """\
+dev: "/path/to/config-file.yaml"
+"prod/pex_config": "s3://bucket/apdb-prod.py"
+"prod/yaml": "s3://bucket/apdb-prod.yaml"
+"""
+
+BAD_INDEX = """\
+dev: ["/path/to/config-file.yaml"]
+prod:
+    pex_config: "s3://bucket/apdb-prod.py"
+    yaml: "s3://bucket/apdb-prod.yaml"
+"""
+
+
+class ApdbIndexTestCase(unittest.TestCase):
+    """A test case for ApdbIndex class."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.mkdtemp()
+        self.valid_index_path = os.path.join(self.tempdir, "apdb-index.yaml")
+        with open(self.valid_index_path, "w") as index_file:
+            index_file.write(VALID_INDEX)
+        self.bad_index_path = os.path.join(self.tempdir, "bad-index.yaml")
+        with open(self.bad_index_path, "w") as index_file:
+            index_file.write(BAD_INDEX)
+        self.missing_index_path = os.path.join(self.tempdir, "missing-index.yaml")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tempdir, ignore_errors=True)
+
+    def test_get_apdb_uri(self) -> None:
+        """Check get_apdb_uri against existing valid file."""
+        index = ApdbIndex(self.valid_index_path)
+        self.assertEqual(index.get_apdb_uri("dev"), ResourcePath("/path/to/config-file.yaml"))
+        self.assertEqual(index.get_apdb_uri("dev", "yaml"), ResourcePath("/path/to/config-file.yaml"))
+        self.assertEqual(index.get_apdb_uri("dev", "anything"), ResourcePath("/path/to/config-file.yaml"))
+        self.assertEqual(index.get_apdb_uri("prod/yaml"), ResourcePath("s3://bucket/apdb-prod.yaml"))
+        self.assertEqual(index.get_apdb_uri("prod/pex_config"), ResourcePath("s3://bucket/apdb-prod.py"))
+        with self.assertRaises(KeyError):
+            index.get_apdb_uri("prod")
+        with self.assertRaises(KeyError):
+            index.get_apdb_uri("prod", "anything")
+        with self.assertRaises(KeyError):
+            index.get_apdb_uri("anything")
+
+    def test_missing_config(self) -> None:
+        """Check get_apdb_uri when index file is missing."""
+        index = ApdbIndex(self.missing_index_path)
+        with self.assertRaises(FileNotFoundError):
+            index.get_apdb_uri("prod")
+
+    def test_bad_config(self) -> None:
+        """Check get_apdb_uri when badly formatted YAML file."""
+        index = ApdbIndex(self.bad_index_path)
+        with self.assertRaises(TypeError):
+            index.get_apdb_uri("prod")
+
+    def test_get_known_labels(self) -> None:
+        """Check get_known_labels."""
+        index = ApdbIndex(self.valid_index_path)
+        self.assertEqual(index.get_known_labels(), {"dev", "prod/yaml", "prod/pex_config"})
+
+        index = ApdbIndex(self.bad_index_path)
+        self.assertEqual(index.get_known_labels(), set())
+
+        index = ApdbIndex(self.missing_index_path)
+        self.assertEqual(index.get_known_labels(), set())
+
+    def test_get_entries(self) -> None:
+        """Check get_entries."""
+        index = ApdbIndex(self.valid_index_path)
+        self.assertEqual(
+            index.get_entries(),
+            {
+                "dev": "/path/to/config-file.yaml",
+                "prod/pex_config": "s3://bucket/apdb-prod.py",
+                "prod/yaml": "s3://bucket/apdb-prod.yaml",
+            },
+        )
+
+        index = ApdbIndex(self.bad_index_path)
+        self.assertEqual(index.get_entries(), {})
+
+        index = ApdbIndex(self.missing_index_path)
+        self.assertEqual(index.get_entries(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ups/dax_apdb.table
+++ b/ups/dax_apdb.table
@@ -1,6 +1,7 @@
 setupRequired(felis)
 setupRequired(geom)
 setupRequired(pex_config)
+setupRequired(resources)
 setupRequired(sconsUtils)
 setupRequired(sdm_schemas)
 setupRequired(sphgeom)


### PR DESCRIPTION
Two new methods `from_url` and `from_config` should be used for creating Apdb instances when a configuration file or configuration object exists. Other factory methods in `factory` module are for internal use only.

New `apdb-cli` script for now has a `create-sql` and `create-cassandra` subcommands which will replace `make_apdb` and its cousins. The commands take a bunch of options, create APDB instance, and write a new config file for it.

Add support for APDB index. Index is a configuration file which maps labels to the URIs of APDB configuration files. Apdb can be instantiated via `from_uri` method using `label:` prefix with the name of the label defined in the index file.