### PR TITLE
DM-43933: Add special service for collecting monitoring metrics

### DIFF
--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -120,7 +120,7 @@ class ApdbCassandraConfig(ApdbConfig):
         doc="Name for consistency level of write operations, default: QUORUM, can be ONE.", default="QUORUM"
     )
     read_timeout = Field[float](doc="Timeout in seconds for read operations.", default=120.0)
-    write_timeout = Field[float](doc="Timeout in seconds for write operations.", default=10.0)
+    write_timeout = Field[float](doc="Timeout in seconds for write operations.", default=60.0)
     remove_timeout = Field[float](doc="Timeout in seconds for remove operations.", default=600.0)
     read_concurrency = Field[int](doc="Concurrency level for read operations.", default=500)
     protocol_version = Field[int](

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -53,7 +53,7 @@ def main(args: Sequence[str] | None = None) -> None:
 def _create_sql_subcommand(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser("create-sql", help="Create new APDB instance in SQL database.")
     parser.add_argument("db_url", help="Database URL in SQLAlchemy format for APDB instance.")
-    parser.add_argument("config_path", help="Name of the new configuration file for created APDB instance.")
+    parser.add_argument("output_config", help="Name of the new configuration file for created APDB instance.")
     options.common_apdb_options(parser)
     options.sql_config_options(parser)
     parser.add_argument(
@@ -68,7 +68,7 @@ def _create_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None
     parser.add_argument(
         "keyspace", help="Cassandra keyspace name for APDB tables, will be created if does not exist."
     )
-    parser.add_argument("config_path", help="Name of the new configuration file for created APDB instance.")
+    parser.add_argument("output_config", help="Name of the new configuration file for created APDB instance.")
     options.common_apdb_options(parser)
     options.cassandra_config_options(parser)
     parser.add_argument(

--- a/python/lsst/dax/apdb/cli/options.py
+++ b/python/lsst/dax/apdb/cli/options.py
@@ -56,8 +56,8 @@ def common_apdb_options(parser: argparse.ArgumentParser) -> None:
     group = parser.add_argument_group("common APDB options")
     _option_from_pex_field(group, ApdbConfig.schema_file, metavar="URL")
     _option_from_pex_field(group, ApdbConfig.schema_name)
-    _option_from_pex_field(group, ApdbConfig.read_sources_months, type=int)
-    _option_from_pex_field(group, ApdbConfig.read_forced_sources_months, type=int)
+    _option_from_pex_field(group, ApdbConfig.read_sources_months, metavar="NUMBER", type=int)
+    _option_from_pex_field(group, ApdbConfig.read_forced_sources_months, metavar="NUMBER", type=int)
     _option_from_pex_field(
         group, ApdbConfig.use_insert_id, name="--enable-replica", action="store_true", default=False
     )

--- a/python/lsst/dax/apdb/monitor.py
+++ b/python/lsst/dax/apdb/monitor.py
@@ -1,0 +1,371 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["MonAgent", "MonService", "LoggingMonHandler"]
+
+import contextlib
+import json
+import logging
+import time
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any
+
+from lsst.utils.classes import Singleton
+
+if TYPE_CHECKING:
+    from contextlib import AbstractContextManager
+
+_TagsType = Mapping[str, str | int]
+
+
+class MonHandler(ABC):
+    """Interface for handlers of the monitoring records.
+
+    Handlers are responsible for delivering monitoring records to their final
+    destination, for example log file or time-series database.
+    """
+
+    @abstractmethod
+    def handle(
+        self, name: str, timestamp: float, tags: _TagsType, values: Mapping[str, Any], agent_name: str
+    ) -> None:
+        """Handle one monitoring record.
+
+        Parameters
+        ----------
+        name : `str`
+            Record name, arbitrary string.
+        timestamp : `str`
+            Time in seconds since UNIX epoch when record originated.
+        tags : `~collections.abc.Mapping` [`str`, `str` or `int`]
+            Tags associated with the record, may be empty.
+        values : `~collections.abc.Mapping` [`str`, `Any`]
+            Values associated with the record, usually never empty.
+        agent_name `str`
+            Name of a client agent that produced this record.
+        """
+        raise NotImplementedError()
+
+
+class MonAgent:
+    """Client-side interface for adding monitoring records to the monitoring
+    service.
+
+    Parameters
+    ----------
+    name : `str`
+        Client agent name, this is used for filtering of the records by the
+        service and ia also passed to monitoring handler as ``agent_name``.
+    """
+
+    def __init__(self, name: str = ""):
+        self._name = name
+        self._service = MonService()
+
+    def add_record(
+        self,
+        name: str,
+        *,
+        values: Mapping[str, Any],
+        tags: Mapping[str, str | int] | None = None,
+        timestamp: float | None = None,
+    ) -> None:
+        """Send one record to monitoring service.
+
+        Parameters
+        ----------
+        name : `str`
+            Record name, arbitrary string.
+        values : `~collections.abc.Mapping` [`str`, `Any`]
+            Values associated with the record, usually never empty.
+        tags : `~collections.abc.Mapping` [`str`, `str` or `int`]
+            Tags associated with the record, may be empty.
+        timestamp : `str`
+            Time in seconds since UNIX epoch when record originated.
+        """
+        self._service._add_record(
+            agent_name=self._name,
+            record_name=name,
+            tags=tags,
+            values=values,
+            timestamp=timestamp,
+        )
+
+    def context_tags(self, tags: _TagsType) -> AbstractContextManager[None]:
+        """Context manager that adds a set of tags to all records created
+        inside the context.
+
+        Parameters
+        ----------
+        tags : `~collections.abc.Mapping` [`str`, `str` or `int`]
+            Tags associated with the records.
+
+        Notes
+        -----
+        All calls to `add_record` that happen inside the corresponding context
+        will add tags specified in this call. Tags specified in `add_record`
+        will override matching tag names that are passed to this method. On
+        exit from context a previous tag context is restored (which may be
+        empty).
+        """
+        return self._service.context_tags(tags)
+
+
+class MonFilter:
+    """Filter for the names associated with client agents.
+
+    Parameters
+    ----------
+    rule : `str`
+        String specifying filtering rule for a single name, or catch-all rule.
+        The rule consist of the agent name prefixed by minus or optional plus
+        sign. Catch-all rule uses name "any". If the rule starts with minus
+        sign then matching agent will be rejected. Otherwise matching agent
+        is accepted.
+    """
+
+    def __init__(self, rule: str):
+        self._accept = True
+        if rule.startswith("-"):
+            self._accept = False
+            rule = rule[1:]
+        elif rule.startswith("+"):
+            rule = rule[1:]
+        self.agent_name = "" if rule == "any" else rule
+
+    def is_match_all(self) -> bool:
+        """Return `True` if this rule is a catch-all rule.
+
+        Returns
+        -------
+        is_match_all : `bool`
+            `True` if rule name is `-any`, `+any`, or `any`.
+        """
+        return not self.agent_name
+
+    def accept(self, agent_name: str) -> bool | None:
+        """Return filtering decision for specified agent name.
+
+        Parameters
+        ----------
+        agent_name : `str`
+            Name of the clent agent that produces monitoring record.
+
+        Returns
+        -------
+        decision : `bool` or `None`
+            `True` if the agent is accepted, `False` if agent is rejected.
+            `None` is returned if this rule does not match agent name and
+            decision should be made by the next rule.
+        """
+        if not self.agent_name or agent_name == self.agent_name:
+            return self._accept
+        return None
+
+
+class MonService(metaclass=Singleton):
+    """Class implementing monitoring service functionality.
+
+    Notes
+    -----
+    This is a singleton class which serves all client agents in an application.
+    It accepts records from agents, filters it based on a set of configured
+    rules and forwards them to one or more configured handlers. By default
+    there are no handlers defined which means that all records are discarded.
+    Default set of filtering rules is empty which accepts all agent names.
+
+    To produce a useful output from this service one has to add at least one
+    handler using `add_handler` method (e.g. `LoggingMonHandler` instance).
+    The `set_filters` methods can be used to specify the set of filtering
+    rules.
+    """
+
+    _handlers: list[MonHandler] = []
+    """List of active handlers."""
+
+    _context_tags: _TagsType | None = None
+    """Current tag context, these tags are added to each new record."""
+
+    _filters: list[MonFilter] = []
+    """Sequence of filters for agent names."""
+
+    def set_filters(self, rules: Iterable[str]) -> None:
+        """Define a sequence of rules for filtering of the agent names.
+
+        Parameters
+        ----------
+        rules : `~collections.abc.Iterable` [`str`]
+            Ordered collection of rules.  Each string specifies filtering rule
+            for a single name, or catch-all rule.  The rule consist of the
+            agent name prefixed by minus or optional plus sign. Catch-all rule
+            uses name "any". If the rule starts with minus sign then matching
+            agent will be rejected. Otherwise matching agent is accepted.
+
+        Notes
+        -----
+        The catch-all rule (`-any`, `+any`, or `any`) can be specified in any
+        location in the sequence but it is always applied last. E.g.
+        `["-any", "+agent1"]` behaves the same as `["+agent1", "-any"]`.
+        If the set of rues does not include catch-all rule, filtering behaves
+        as if it is added implicitly as `+any`.
+
+        Filtering code evaluates each rule in order. First rule that matches
+        the agent name wins. Agent names are matched literally, wildcards are
+        not supported and there are no parent/child relations between agent
+        names (e.g `lsst.dax.apdb` and `lsst.dax.apdb.sql` are treated as
+        independent names).
+        """
+        match_all: MonFilter | None = None
+        self._filters = []
+        for rule in rules:
+            mon_filter = MonFilter(rule)
+            if mon_filter.is_match_all():
+                match_all = mon_filter
+            else:
+                self._filters.append(mon_filter)
+        if match_all:
+            self._filters.append(match_all)
+
+    def _add_record(
+        self,
+        *,
+        agent_name: str,
+        record_name: str,
+        values: Mapping[str, Any],
+        tags: Mapping[str, str | int] | None = None,
+        timestamp: float | None = None,
+    ) -> None:
+        """Add one monitoring record, this method is for use by agents only."""
+        if self._handlers:
+            accept: bool | None = None
+            # Check every filter, accept if none makes any decision.
+            for filter in self._filters:
+                accept = filter.accept(agent_name)
+                if accept is False:
+                    return
+                if accept is True:
+                    break
+            if timestamp is None:
+                timestamp = time.time()
+            if tags is None:
+                tags = self._context_tags or {}
+            else:
+                if self._context_tags:
+                    all_tags = dict(self._context_tags)
+                    all_tags.update(tags)
+                    tags = all_tags
+            for handler in self._handlers:
+                handler.handle(record_name, timestamp, tags, values, agent_name)
+
+    @property
+    def handlers(self) -> Iterable[MonHandler]:
+        """Set of handlers defined currently."""
+        return self._handlers
+
+    def add_handler(self, handler: MonHandler) -> None:
+        """Add one monitoring handler.
+
+        Parameters
+        ----------
+        handler : `MonHandler`
+            Handler instance.
+        """
+        if handler not in self._handlers:
+            self._handlers.append(handler)
+
+    def remove_handler(self, handler: MonHandler) -> None:
+        """Add one monitoring handler.
+
+        Parameters
+        ----------
+        handler : `MonHandler`
+            Handler instance.
+        """
+        if handler in self._handlers:
+            self._handlers.remove(handler)
+
+    def _add_context_tags(self, tags: _TagsType) -> _TagsType | None:
+        """Extend the tag context with new tags, overriding any tags that may
+        already exist in a current context.
+        """
+        old_tags = self._context_tags
+        if not self._context_tags:
+            self._context_tags = tags
+        else:
+            all_tags = dict(self._context_tags)
+            all_tags.update(tags)
+            self._context_tags = all_tags
+        return old_tags
+
+    @contextlib.contextmanager
+    def context_tags(self, tags: _TagsType) -> Iterator[None]:
+        """Context manager that adds a set of tags to all records created
+        inside the context.
+
+        Typically clients will be using `MonAgent.context_tags`, which forwards
+        to this method.
+        """
+        old_context = self._add_context_tags(tags)
+        try:
+            yield
+        finally:
+            # Restore old context.
+            self._context_tags = old_context
+
+
+class LoggingMonHandler(MonHandler):
+    """Implementation of the monitoring handler which dumps records formatted
+    as JSON objects to `logging`.
+
+    Parameters
+    ----------
+    logger_name : `str`
+        Name of the `logging` logger to use for output.
+    log_level : `int`, optional
+        Logging level to use for output, default is `INFO`
+
+    Notes
+    -----
+    The attributes of the formatted JSON object correspond to the parameters
+    of `handle` method, except for `agent_name` which is mapped to `source`.
+    The `tags` and `values` become JSON sub-objects with corresponding keys.
+    """
+
+    def __init__(self, logger_name: str, log_level: int = logging.INFO):
+        self._logger = logging.getLogger(logger_name)
+        self._level = log_level
+
+    def handle(
+        self, name: str, timestamp: float, tags: _TagsType, values: Mapping[str, Any], agent_name: str
+    ) -> None:
+        # Docstring is inherited from base class.
+        record = {
+            "name": name,
+            "timestamp": timestamp,
+            "tags": tags,
+            "values": values,
+            "source": agent_name,
+        }
+        msg = json.dumps(record)
+        self._logger.log(self._level, msg)

--- a/python/lsst/dax/apdb/scripts/create_cassandra.py
+++ b/python/lsst/dax/apdb/scripts/create_cassandra.py
@@ -28,12 +28,12 @@ from typing import Any
 from ..cassandra import ApdbCassandra
 
 
-def create_cassandra(config_path: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
+def create_cassandra(output_config: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
     """Create new APDB instance in Cassandra cluster.
 
     Parameters
     ----------
-    config_path : `str`
+    output_config : `str`
         Name of the file to write APDB configuration.
     ra_dec_columns : `str` or `None`
         Comma-separated list of names for ra/dec columns in DiaObject table.
@@ -45,4 +45,4 @@ def create_cassandra(config_path: str, ra_dec_columns: str | None, **kwargs: Any
         ra_dec_list = ra_dec_columns.split(",")
     kwargs["hosts"] = kwargs.pop("host")
     config = ApdbCassandra.init_database(ra_dec_columns=ra_dec_list, **kwargs)
-    config.save(config_path)
+    config.save(output_config)

--- a/python/lsst/dax/apdb/scripts/create_sql.py
+++ b/python/lsst/dax/apdb/scripts/create_sql.py
@@ -28,12 +28,12 @@ from typing import Any
 from ..sql import ApdbSql
 
 
-def create_sql(config_path: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
+def create_sql(output_config: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
     """Create new APDB instance in SQL database.
 
     Parameters
     ----------
-    config_path : `str`
+    output_config : `str`
         Name of the file to write APDB configuration.
     ra_dec_columns : `str` or `None`
         Comma-separated list of names for ra/dec columns in DiaObject table.
@@ -44,4 +44,4 @@ def create_sql(config_path: str, ra_dec_columns: str | None, **kwargs: Any) -> N
     if ra_dec_columns:
         ra_dec_list = ra_dec_columns.split(",")
     config = ApdbSql.init_database(ra_dec_columns=ra_dec_list, **kwargs)
-    config.save(config_path)
+    config.save(output_config)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,199 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from collections.abc import Mapping
+from typing import Any
+
+from lsst.dax.apdb import monitor, timer
+
+
+class _TestHandler(monitor.MonHandler):
+    """Implementation of monitoring handler used in unit tests."""
+
+    name: str
+    tags: Mapping
+    values: Mapping
+    agent_name: str
+
+    def handle(
+        self, name: str, timestamp: float, tags: monitor._TagsType, values: Mapping[str, Any], agent_name: str
+    ) -> None:
+        self.name = name
+        self.tags = tags
+        self.values = values
+        self.agent_name = agent_name
+
+
+class MonitorTestCase(unittest.TestCase):
+    """Unit tests for monitoring classes."""
+
+    def setUp(self) -> None:
+        # MonService is a singleton wit global/shared test, need to reset it
+        # for each new test.
+        monsvc = monitor.MonService()
+        monsvc._handlers = []
+        monsvc._context_tags = None
+        monsvc._filters = []
+
+    def test_simple(self) -> None:
+        """Test few simple calls."""
+        handler = _TestHandler()
+        monitor.MonService().add_handler(handler)
+
+        agent = monitor.MonAgent("007")
+        agent.add_record("mon", values={"quantity": 1})
+
+        self.assertEqual(handler.name, "mon")
+        self.assertEqual(handler.tags, {})
+        self.assertEqual(handler.values, {"quantity": 1})
+        self.assertEqual(handler.agent_name, "007")
+
+    def test_two_handlers(self) -> None:
+        """Test few simple calls with two handlers."""
+        handler1 = _TestHandler()
+        monitor.MonService().add_handler(handler1)
+        handler2 = _TestHandler()
+        monitor.MonService().add_handler(handler2)
+
+        agent = monitor.MonAgent("007")
+        agent.add_record("mon", values={"quantity": 1}, tags={"tag1": "atag"})
+
+        self.assertEqual(handler1.name, "mon")
+        self.assertEqual(handler1.tags, {"tag1": "atag"})
+        self.assertEqual(handler1.values, {"quantity": 1})
+        self.assertEqual(handler1.agent_name, "007")
+        self.assertEqual(handler2.name, "mon")
+        self.assertEqual(handler2.tags, {"tag1": "atag"})
+        self.assertEqual(handler2.values, {"quantity": 1})
+        self.assertEqual(handler2.agent_name, "007")
+
+    def test_tag_context(self) -> None:
+        """Test tag context."""
+        handler = _TestHandler()
+        monitor.MonService().add_handler(handler)
+
+        agent = monitor.MonAgent("007")
+
+        with agent.context_tags({"tag1": "atag"}):
+            agent.add_record("mon", values={"quantity": 1})
+
+        self.assertEqual(handler.name, "mon")
+        self.assertEqual(handler.tags, {"tag1": "atag"})
+        self.assertEqual(handler.values, {"quantity": 1})
+        self.assertEqual(handler.agent_name, "007")
+
+    def test_logging_handler(self) -> None:
+        """Test logging handler."""
+        handler = monitor.LoggingMonHandler("logger")
+        monitor.MonService().add_handler(handler)
+
+        agent = monitor.MonAgent("007")
+
+        with self.assertLogs("logger", level="INFO") as cm:
+            # Need to use fixed timestamps here to be able to compare strings.
+            agent.add_record("mon", values={"quantity": 1}, tags={"tag1": "atag1"}, timestamp=100.0)
+            agent.add_record("mon", values={"quantity": 2}, tags={"tag1": "atag2"}, timestamp=101.0)
+        self.assertEqual(
+            cm.output,
+            [
+                'INFO:logger:{"name": "mon", "timestamp": 100.0, '
+                '"tags": {"tag1": "atag1"}, "values": {"quantity": 1}, "source": "007"}',
+                'INFO:logger:{"name": "mon", "timestamp": 101.0, '
+                '"tags": {"tag1": "atag2"}, "values": {"quantity": 2}, "source": "007"}',
+            ],
+        )
+
+    def test_timer(self) -> None:
+        """Test monitoring output via Timer."""
+        handler = _TestHandler()
+        monitor.MonService().add_handler(handler)
+
+        agent = monitor.MonAgent("007")
+        with agent.context_tags({"tag1": "atag"}):
+            with timer.Timer("timer", agent):
+                pass
+        self.assertEqual(handler.name, "timer")
+        self.assertEqual(handler.tags, {"tag1": "atag"})
+        self.assertEqual(set(handler.values), {"real", "user", "sys"})
+        self.assertEqual(handler.agent_name, "007")
+
+    def test_filters(self) -> None:
+        """Test agent filtering."""
+        handler = _TestHandler()
+        monitor.MonService().add_handler(handler)
+
+        # Note that unlike in the `logging` there is no parent/child relation
+        # between agent, disabling "lsst" will not disable two others.
+        agent1 = monitor.MonAgent("lsst.agent1")
+        agent2 = monitor.MonAgent("lsst.agent2")
+        agent3 = monitor.MonAgent("lsst")
+
+        # By default nothing is filtered
+        agent1.add_record("mon1", values={"quantity": 1})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+        agent2.add_record("mon2", values={"quantity": 2})
+        self.assertEqual(handler.name, "mon2")
+        self.assertEqual(handler.values["quantity"], 2)
+        agent3.add_record("mon3", values={"quantity": 3})
+        self.assertEqual(handler.name, "mon3")
+        self.assertEqual(handler.values["quantity"], 3)
+
+        # Disable one of them.
+        monitor.MonService().set_filters(["-lsst"])
+        agent1.add_record("mon1", values={"quantity": 1})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+        agent2.add_record("mon2", values={"quantity": 2})
+        self.assertEqual(handler.name, "mon2")
+        self.assertEqual(handler.values["quantity"], 2)
+        agent3.add_record("mon3", values={"quantity": 3})
+        self.assertEqual(handler.name, "mon2")
+        self.assertEqual(handler.values["quantity"], 2)
+
+        # Disable all except one.
+        monitor.MonService().set_filters(["+lsst.agent1", "-any"])
+        agent1.add_record("mon1", values={"quantity": 1})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+        agent2.add_record("mon2", values={"quantity": 2})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+        agent3.add_record("mon3", values={"quantity": 3})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+
+        # Plus sign is optional in the rule.
+        monitor.MonService().set_filters(["+lsst.agent1", "lsst.agent2", "-lsst"])
+        agent1.add_record("mon1", values={"quantity": 1})
+        self.assertEqual(handler.name, "mon1")
+        self.assertEqual(handler.values["quantity"], 1)
+        agent2.add_record("mon2", values={"quantity": 2})
+        self.assertEqual(handler.name, "mon2")
+        self.assertEqual(handler.values["quantity"], 2)
+        agent3.add_record("mon3", values={"quantity": 3})
+        self.assertEqual(handler.name, "mon2")
+        self.assertEqual(handler.values["quantity"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New service can collect monitoring records (which is a collection of
tags and values) and publish them somewhere. For now publishing
to log stream is supported with records formatted as JSON objects.
Timer class is updated to publish timing info to monitoring service
in addition to logs.