### PR TITLE
DM-43416: Standardize module documentation

### DIFF
--- a/doc/lsst.dax.apdb/index.rst
+++ b/doc/lsst.dax.apdb/index.rst
@@ -24,7 +24,7 @@ Contributing
 ============
 
 ``lsst.dax.apdb`` is developed at https://github.com/lsst/dax_apdb.
-You can find Jira issues for this module under the `dax_apdb <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20dax_apdb>`_ component.
+You can find Jira issues for this module under the `dax_apdb <https://rubinobs.atlassian.net/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20dax_apdb>`_ component.
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 

--- a/doc/lsst.dax.apdb/index.rst
+++ b/doc/lsst.dax.apdb/index.rst
@@ -28,6 +28,22 @@ You can find Jira issues for this module under the `dax_apdb <https://rubinobs.a
 
 .. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
 
+.. _lsst.dax.apdb-scripts:
+
+Script reference
+================
+
+This package provides a command line utility that can be used for some management operations.
+The name of the CLI script is ``apdb-cli`` and it has a number of subcommands:
+
+  - ``create-sql`` is used to create new APDB instances based on SQL relational database technology.
+
+  - ``create-cassandra`` is used to create new APDB instances based on Cassandra storage technology.
+
+  - ``list-index`` dumps the contents of the APDB index file.
+
+Each sub-command provides command line help describing its arguments.
+
 .. _lsst.dax.apdb-pyapi:
 
 Python API reference
@@ -40,18 +56,3 @@ Python API reference
 .. automodapi:: lsst.dax.apdb.schema_model
    :no-main-docstr:
    :no-inheritance-diagram:
-
-
-Command line tools
-==================
-
-This package provides a command line utility that can be used for some management operations.
-The name of the CLI script is ``apdb-cli`` and it has a number of subcommands:
-
-  - ``create-sql`` is used to create new APDB instances based on SQL relational database technology.
-
-  - ``create-cassandra`` is used to create new APDB instances based on Cassandra storage technology.
-
-  - ``list-index`` dumps the contents of the APDB index file.
-
-Each sub-command provides command line help describing its arguments.


### PR DESCRIPTION
This PR brings the "Command line tools" section of the docs in line with [the module homepage topic type guidelines](https://developer.lsst.io/stack/module-homepage-topic-type.html#script-reference-section), including making the section linkable from other docs.