### PR TITLE
DM-43623: Check replication factor for existing keyspaces

### DIFF
--- a/python/lsst/dax/apdb/cassandra/__init__.py
+++ b/python/lsst/dax/apdb/cassandra/__init__.py
@@ -21,3 +21,4 @@
 
 from .apdbCassandra import *
 from .apdbCassandraReplica import *
+from .apdbCassandraSchema import CreateTableOptions, TableOptions

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["ApdbCassandraSchema"]
+__all__ = ["ApdbCassandraSchema", "CreateTableOptions", "TableOptions"]
 
 import enum
 import logging
@@ -29,6 +29,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, cast
 
 import felis.datamodel
+import pydantic
 
 from .. import schema_model
 from ..apdbSchema import ApdbSchema, ApdbTables
@@ -42,6 +43,36 @@ _LOG = logging.getLogger(__name__)
 
 class InconsistentSchemaError(RuntimeError):
     """Exception raised when schema state is inconsistent."""
+
+
+class TableOptions(pydantic.BaseModel):
+    """Set of per-table options for creating Cassandra tables."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    tables: list[str]
+    """List of table names for which the options should be applied."""
+
+    options: str
+
+
+class CreateTableOptions(pydantic.BaseModel):
+    """Set of options for creating Cassandra tables."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    table_options: list[TableOptions] = pydantic.Field(default_factory=list)
+    """Collection of per-table options."""
+
+    default_table_options: str = ""
+    """Default options used for tables that are not in the above list."""
+
+    def get_options(self, table_name: str) -> str:
+        """Find table options for a given table name."""
+        for table_options in self.table_options:
+            if table_name in table_options.tables:
+                return table_options.options
+        return self.default_table_options
 
 
 @enum.unique
@@ -473,6 +504,7 @@ class ApdbCassandraSchema(ApdbSchema):
         drop: bool = False,
         part_range: tuple[int, int] | None = None,
         replication_factor: int | None = None,
+        table_options: CreateTableOptions | None = None,
     ) -> None:
         """Create or re-create all tables.
 
@@ -517,9 +549,9 @@ class ApdbCassandraSchema(ApdbSchema):
             self._session.execute(query)
 
         for table in self._apdb_tables:
-            self._makeTableSchema(table, drop, part_range)
+            self._makeTableSchema(table, drop, part_range, table_options)
         for extra_table in self._extra_tables:
-            self._makeTableSchema(extra_table, drop, part_range)
+            self._makeTableSchema(extra_table, drop, part_range, table_options)
         # Reset cached information.
         self._has_replica_chunks = None
 
@@ -528,6 +560,7 @@ class ApdbCassandraSchema(ApdbSchema):
         table: ApdbTables | ExtraTables,
         drop: bool = False,
         part_range: tuple[int, int] | None = None,
+        table_options: CreateTableOptions | None = None,
     ) -> None:
         _LOG.debug("Making table %s", table)
 
@@ -548,10 +581,13 @@ class ApdbCassandraSchema(ApdbSchema):
                 _LOG.debug("query finished: %s", future.query)
 
         queries = []
+        options = table_options.get_options(fullTable).strip() if table_options else None
         for table_name in table_list:
             if_not_exists = "" if drop else "IF NOT EXISTS"
             columns = ", ".join(self._tableColumns(table))
             query = f'CREATE TABLE {if_not_exists} "{self._keyspace}"."{table_name}" ({columns})'
+            if options:
+                query = f"{query} WITH {options}"
             _LOG.debug("query: %s", query)
             queries.append(query)
         futures = [self._session.execute_async(query, timeout=None) for query in queries]

--- a/python/lsst/dax/apdb/cli/options.py
+++ b/python/lsst/dax/apdb/cli/options.py
@@ -99,6 +99,9 @@ def cassandra_config_options(parser: argparse.ArgumentParser) -> None:
     group.add_argument(
         "--replication-factor", help="Replication factor used when creating new keyspace.", type=int
     )
+    group.add_argument(
+        "--table-options", help="Path or URI of YAML file containing table options.", metavar="URI"
+    )
     _option_from_pex_field(
         group, ApdbCassandraConfig.read_consistency, choices=["ONE", "TWO", "THREE", "QUORUM", "ALL"]
     )

--- a/python/lsst/dax/apdb/scripts/create_cassandra.py
+++ b/python/lsst/dax/apdb/scripts/create_cassandra.py
@@ -23,12 +23,18 @@ from __future__ import annotations
 
 __all__ = ["create_cassandra"]
 
+import io
 from typing import Any
 
-from ..cassandra import ApdbCassandra
+import yaml
+from lsst.resources import ResourcePath
+
+from ..cassandra import ApdbCassandra, CreateTableOptions
 
 
-def create_cassandra(output_config: str, ra_dec_columns: str | None, **kwargs: Any) -> None:
+def create_cassandra(
+    output_config: str, ra_dec_columns: str | None, table_options: str | None = None, **kwargs: Any
+) -> None:
     """Create new APDB instance in Cassandra cluster.
 
     Parameters
@@ -37,12 +43,28 @@ def create_cassandra(output_config: str, ra_dec_columns: str | None, **kwargs: A
         Name of the file to write APDB configuration.
     ra_dec_columns : `str` or `None`
         Comma-separated list of names for ra/dec columns in DiaObject table.
+    table_options : `str`, optional
+        Path or URI of the YAML file with table options.
     **kwargs
         Keyword arguments passed to `ApdbCassandra.init_database` method.
     """
+    options = _read_table_options(table_options)
     ra_dec_list: list[str] | None = None
     if ra_dec_columns:
         ra_dec_list = ra_dec_columns.split(",")
     kwargs["hosts"] = kwargs.pop("host")
-    config = ApdbCassandra.init_database(ra_dec_columns=ra_dec_list, **kwargs)
+    config = ApdbCassandra.init_database(ra_dec_columns=ra_dec_list, table_options=options, **kwargs)
     config.save(output_config)
+
+
+def _read_table_options(table_options: str | None = None) -> CreateTableOptions | None:
+    """Read contents of the table options file."""
+    if not table_options:
+        return None
+
+    res = ResourcePath(table_options)
+    content = res.read()
+    stream = io.BytesIO(content)
+    if model_data := yaml.load(stream, Loader=yaml.SafeLoader):
+        return CreateTableOptions.model_validate(model_data)
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astropy
-numpy
+numpy < 2.0
 pandas
 pydantic
 pyyaml >= 5.1


### PR DESCRIPTION
When creating a schema in an existing keyspace the code now will check its
replication factor and raise if it does not match requested one.

Also introduce a way to specify table options when creating tables.
`create-cassandra` CLI adds `--table-options` option pointing to a YAML file with
table options.