### PR TITLE
DM-44237: Fix short integer type mapping; add CLI for metadata access

### DIFF
--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -426,12 +426,12 @@ class ApdbCassandra(Apdb):
 
         # For now there is no way to make read-only APDB instances, assume that
         # any access can do updates.
-        if not self._schema.schemaVersion().checkCompatibility(db_schema_version, True):
+        if not self._schema.schemaVersion().checkCompatibility(db_schema_version):
             raise IncompatibleVersionError(
                 f"Configured schema version {self._schema.schemaVersion()} "
                 f"is not compatible with database version {db_schema_version}"
             )
-        if not self.apdbImplementationVersion().checkCompatibility(db_code_version, True):
+        if not self.apdbImplementationVersion().checkCompatibility(db_code_version):
             raise IncompatibleVersionError(
                 f"Current code version {self.apdbImplementationVersion()} "
                 f"is not compatible with database version {db_code_version}"
@@ -441,7 +441,7 @@ class ApdbCassandra(Apdb):
         if self._schema.has_replica_chunks:
             db_replica_version = _get_version(self.metadataReplicaVersionKey, initial_version)
             code_replica_version = ApdbCassandraReplica.apdbReplicaImplementationVersion()
-            if not code_replica_version.checkCompatibility(db_replica_version, True):
+            if not code_replica_version.checkCompatibility(db_replica_version):
                 raise IncompatibleVersionError(
                     f"Current replication code version {code_replica_version} "
                     f"is not compatible with database version {db_replica_version}"

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -107,7 +107,7 @@ class ApdbCassandraSchema(ApdbSchema):
         felis.datamodel.DataType.timestamp: "TIMESTAMP",
         felis.datamodel.DataType.long: "BIGINT",
         felis.datamodel.DataType.int: "INT",
-        felis.datamodel.DataType.short: "INT",
+        felis.datamodel.DataType.short: "SMALLINT",
         felis.datamodel.DataType.byte: "TINYINT",
         felis.datamodel.DataType.binary: "BLOB",
         felis.datamodel.DataType.char: "TEXT",

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -40,6 +40,7 @@ def main(args: Sequence[str] | None = None) -> None:
     _create_sql_subcommand(subparsers)
     _create_cassandra_subcommand(subparsers)
     _list_index_subcommand(subparsers)
+    _metadata_subcommand(subparsers)
 
     parsed_args = parser.parse_args(args)
     log_cli.process_args(parsed_args)
@@ -83,3 +84,55 @@ def _list_index_subcommand(subparsers: argparse._SubParsersAction) -> None:
         "index_path", help="Location of index file, if missing then $DAX_APDB_INDEX_URI is used.", nargs="?"
     )
     parser.set_defaults(method=scripts.list_index)
+
+
+def _metadata_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("metadata", help="Operations with APDB metadata table.")
+    subparsers = parser.add_subparsers(title="available subcommands", required=True)
+    _metadata_set_subcommand(subparsers)
+    _metadata_get_subcommand(subparsers)
+    _metadata_show_subcommand(subparsers)
+    _metadata_delete_subcommand(subparsers)
+
+
+def _metadata_show_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("show", help="Show contents of APDB metadata table.")
+    parser.add_argument(
+        "-j",
+        "--json",
+        dest="use_json",
+        help="Dump metadata in JSON format.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument("config", help="Path or URI of APDB configuration file.")
+    parser.set_defaults(method=scripts.metadata_show)
+
+
+def _metadata_get_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("get", help="Print value of the metadata item.")
+    parser.add_argument("config", help="Path or URI of APDB configuration file.")
+    parser.add_argument("key", help="Metadata key, arbitrary string.")
+    parser.set_defaults(method=scripts.metadata_get)
+
+
+def _metadata_set_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("set", help="Add or update metadata item.")
+    parser.add_argument(
+        "-f",
+        "--force",
+        help="Force update of the existing key.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument("config", help="Path or URI of APDB configuration file.")
+    parser.add_argument("key", help="Metadata key, arbitrary string.")
+    parser.add_argument("value", help="Corresponding metadata value.")
+    parser.set_defaults(method=scripts.metadata_set)
+
+
+def _metadata_delete_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("delete", help="Delete metadata item.")
+    parser.add_argument("config", help="Path or URI of APDB configuration file.")
+    parser.add_argument("key", help="Metadata key, arbitrary string.")
+    parser.set_defaults(method=scripts.metadata_delete)

--- a/python/lsst/dax/apdb/scripts/__init__.py
+++ b/python/lsst/dax/apdb/scripts/__init__.py
@@ -22,3 +22,4 @@
 from .create_cassandra import create_cassandra
 from .create_sql import create_sql
 from .list_index import list_index
+from .metadata import metadata_delete, metadata_get, metadata_set, metadata_show

--- a/python/lsst/dax/apdb/scripts/metadata.py
+++ b/python/lsst/dax/apdb/scripts/metadata.py
@@ -1,0 +1,99 @@
+# This file is part of dax_apdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["metadata_delete", "metadata_get", "metadata_set", "metadata_show"]
+
+import json
+import sys
+
+from ..apdb import Apdb
+
+
+def metadata_delete(config: str, key: str) -> None:
+    """Delete metadata key.
+
+    Parameters
+    ----------
+    config : `str`
+        Path or URI of APDB configuration file.
+    key : `str`
+        Metadata key.
+    """
+    apdb = Apdb.from_uri(config)
+    apdb.metadata.delete(key)
+
+
+def metadata_get(config: str, key: str) -> None:
+    """Print value of the metadata item.
+
+    Parameters
+    ----------
+    config : `str`
+        Path or URI of APDB configuration file.
+    key : `str`
+        Metadata key.
+    """
+    apdb = Apdb.from_uri(config)
+    value = apdb.metadata.get(key)
+    if value is None:
+        raise KeyError(f"Metadata key {key!r} does not exist.")
+    else:
+        print(value)
+
+
+def metadata_set(config: str, key: str, value: str, force: bool) -> None:
+    """Add or update metadata item.
+
+    Parameters
+    ----------
+    config : `str`
+        Path or URI of APDB configuration file.
+    key : `str`
+        Metadata key.
+    value : `str`
+        Metadata value.
+    force : `bool`
+        Set to True to allow updates for existing keys.
+    """
+    apdb = Apdb.from_uri(config)
+    apdb.metadata.set(key, value, force=force)
+
+
+def metadata_show(config: str, use_json: bool) -> None:
+    """Show contents of APDB metadata table.
+
+    Parameters
+    ----------
+    config : `str`
+        Path or URI of APDB configuration file.
+    use_json : `bool`
+        If True dump in JSON format.
+    """
+    apdb = Apdb.from_uri(config)
+    if use_json:
+        data = {key: value for key, value in apdb.metadata.items()}
+        json.dump(data, sys.stdout, indent=2)
+        print()
+    else:
+        for key, value in apdb.metadata.items():
+            print(f"{key}: {value}")

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -321,12 +321,12 @@ class ApdbSql(Apdb):
 
         # For now there is no way to make read-only APDB instances, assume that
         # any access can do updates.
-        if not self._schema.schemaVersion().checkCompatibility(db_schema_version, True):
+        if not self._schema.schemaVersion().checkCompatibility(db_schema_version):
             raise IncompatibleVersionError(
                 f"Configured schema version {self._schema.schemaVersion()} "
                 f"is not compatible with database version {db_schema_version}"
             )
-        if not self.apdbImplementationVersion().checkCompatibility(db_code_version, True):
+        if not self.apdbImplementationVersion().checkCompatibility(db_code_version):
             raise IncompatibleVersionError(
                 f"Current code version {self.apdbImplementationVersion()} "
                 f"is not compatible with database version {db_code_version}"
@@ -336,7 +336,7 @@ class ApdbSql(Apdb):
         if self._schema.has_replica_chunks:
             db_replica_version = _get_version(self.metadataReplicaVersionKey, initial_version)
             code_replica_version = ApdbSqlReplica.apdbReplicaImplementationVersion()
-            if not code_replica_version.checkCompatibility(db_replica_version, True):
+            if not code_replica_version.checkCompatibility(db_replica_version):
                 raise IncompatibleVersionError(
                     f"Current replication code version {code_replica_version} "
                     f"is not compatible with database version {db_replica_version}"

--- a/python/lsst/dax/apdb/sql/modelToSql.py
+++ b/python/lsst/dax/apdb/sql/modelToSql.py
@@ -113,8 +113,8 @@ class ModelToSql:
             felis.datamodel.DataType.timestamp: sqlalchemy.types.TIMESTAMP,
             felis.datamodel.DataType.long: sqlalchemy.types.BigInteger,
             felis.datamodel.DataType.int: sqlalchemy.types.Integer,
-            felis.datamodel.DataType.short: sqlalchemy.types.Integer,
-            felis.datamodel.DataType.byte: sqlalchemy.types.Integer,
+            felis.datamodel.DataType.short: sqlalchemy.types.SmallInteger,
+            felis.datamodel.DataType.byte: sqlalchemy.types.SmallInteger,  # Byte types are not very portable
             felis.datamodel.DataType.binary: sqlalchemy.types.LargeBinary,
             felis.datamodel.DataType.text: sqlalchemy.types.Text,
             felis.datamodel.DataType.string: sqlalchemy.types.CHAR,

--- a/python/lsst/dax/apdb/versionTuple.py
+++ b/python/lsst/dax/apdb/versionTuple.py
@@ -80,7 +80,7 @@ class VersionTuple(NamedTuple):
             raise ValueError(f"Invalid version  string '{versionStr}', must consist of three numbers")
         return cls(*version)
 
-    def checkCompatibility(self, database_version: VersionTuple, update: bool) -> bool:
+    def checkCompatibility(self, database_version: VersionTuple) -> bool:
         """Compare implementation schema version with schema version in
         database.
 
@@ -88,8 +88,6 @@ class VersionTuple(NamedTuple):
         ----------
         database_version : `VersionTuple`
             Version of the database schema.
-        update : `bool`
-            If True then read-write access is expected.
 
         Returns
         -------
@@ -102,17 +100,16 @@ class VersionTuple(NamedTuple):
 
             - if major numbers differ, schemas are not compatible;
             - otherwise, if minor versions are different then newer version can
-              read schema made by older version, but cannot write into it;
-              older version can neither read nor write into newer schema;
+              read and write schema made by older version; older version can
+              neither read nor write into newer schema;
             - otherwise, different patch versions are totally compatible.
         """
         if self.major != database_version.major:
             # different major versions are not compatible at all
             return False
         if self.minor != database_version.minor:
-            # different minor versions are backward compatible for read
-            # access only
-            return self.minor > database_version.minor and not update
+            # Different minor versions are backward compatible.
+            return self.minor > database_version.minor
         # patch difference does not matter
         return True
 


### PR DESCRIPTION
Short integer type was mapped to regular 4-byte integers (though we did not have short integers in the schema until 1.0.0). Short will now use SmallInteger for SQL and SMALLINT for Cassandra.

CLI command is added to dump/set/delete metadata table keys.

Also fixed version compatibility rules for minor version numbers.