### PR TITLE
DM-44275: Remove version number access from Apdb interface

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -41,7 +41,6 @@ from .schema_model import Table
 
 if TYPE_CHECKING:
     from .apdbMetadata import ApdbMetadata
-    from .versionTuple import VersionTuple
 
 
 def _data_file_name(basename: str) -> str:
@@ -135,29 +134,6 @@ class Apdb(ABC):
         # Assume that this is ApdbConfig, make_apdb will raise if not.
         config = cast(ApdbConfig, Config._fromPython(config_str))
         return make_apdb(config)
-
-    @classmethod
-    @abstractmethod
-    def apdbImplementationVersion(cls) -> VersionTuple:
-        """Return version number for current APDB implementation.
-
-        Returns
-        -------
-        version : `VersionTuple`
-            Version of the code defined in implementation class.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def apdbSchemaVersion(self) -> VersionTuple:
-        """Return schema version number as defined in config file.
-
-        Returns
-        -------
-        version : `VersionTuple`
-            Version of the schema defined in schema config file.
-        """
-        raise NotImplementedError()
 
     @abstractmethod
     def tableDef(self, table: ApdbTables) -> Table | None:

--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -449,12 +449,14 @@ class ApdbCassandra(Apdb):
 
     @classmethod
     def apdbImplementationVersion(cls) -> VersionTuple:
-        # Docstring inherited from base class.
-        return VERSION
+        """Return version number for current APDB implementation.
 
-    def apdbSchemaVersion(self) -> VersionTuple:
-        # Docstring inherited from base class.
-        return self._schema.schemaVersion()
+        Returns
+        -------
+        version : `VersionTuple`
+            Version of the code defined in implementation class.
+        """
+        return VERSION
 
     def tableDef(self, table: ApdbTables) -> Table | None:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -344,7 +344,13 @@ class ApdbSql(Apdb):
 
     @classmethod
     def apdbImplementationVersion(cls) -> VersionTuple:
-        # Docstring inherited from base class.
+        """Return version number for current APDB implementation.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Version of the code defined in implementation class.
+        """
         return VERSION
 
     @classmethod
@@ -434,10 +440,6 @@ class ApdbSql(Apdb):
         cls._makeSchema(config, drop=drop)
 
         return config
-
-    def apdbSchemaVersion(self) -> VersionTuple:
-        # Docstring inherited from base class.
-        return self._schema.schemaVersion()
 
     def get_replica(self) -> ApdbSqlReplica:
         """Return `ApdbReplica` instance for this database."""

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -678,17 +678,21 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         default_schema = config.schema_file
         apdb = Apdb.from_config(config)
-        self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 1))
+        self.assertEqual(apdb._schema.schemaVersion(), VersionTuple(0, 1, 1))  # type: ignore[attr-defined]
 
         with update_schema_yaml(default_schema, version="") as schema_file:
             config = self.make_instance(schema_file=schema_file)
             apdb = Apdb.from_config(config)
-            self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 0))
+            self.assertEqual(
+                apdb._schema.schemaVersion(), VersionTuple(0, 1, 0)  # type: ignore[attr-defined]
+            )
 
         with update_schema_yaml(default_schema, version="99.0.0") as schema_file:
             config = self.make_instance(schema_file=schema_file)
             apdb = Apdb.from_config(config)
-            self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(99, 0, 0))
+            self.assertEqual(
+                apdb._schema.schemaVersion(), VersionTuple(99, 0, 0)  # type: ignore[attr-defined]
+            )
 
     def test_config_freeze(self) -> None:
         """Test that some config fields are correctly frozen in database."""
@@ -749,7 +753,7 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        self.assertEqual(apdb.apdbSchemaVersion(), VersionTuple(0, 1, 1))
+        self.assertEqual(apdb._schema.schemaVersion(), VersionTuple(0, 1, 1))  # type: ignore[attr-defined]
 
         # Claim that schema version is now 99.0.0, must raise an exception.
         with update_schema_yaml(config.schema_file, version="99.0.0") as schema_file:

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -38,7 +38,7 @@ import logging
 import os
 import unittest
 import uuid
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 try:
     from cassandra.cluster import EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile
@@ -102,10 +102,6 @@ class ApdbCassandraMixin:
         # Delete per-test keyspace.
         query = f"DROP KEYSPACE {self.keyspace}"
         self._run_query(query)
-
-    if TYPE_CHECKING:
-        # For mypy.
-        def make_instance(self, **kwargs: Any) -> ApdbConfig: ...
 
 
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):


### PR DESCRIPTION
Regular clients of Apdb interface do not need to know about versions, all version-related issues are handled internally. Removing to avoid accidental use of those methods.