### PR TITLE
DM-41671: Implement Apdb.containsVisitDetector for Cassandra

### DIFF
--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -262,7 +262,7 @@ class ApdbTest(TestCaseMixin, ABC):
             with self.assertRaises(NotImplementedError):
                 apdb.getDiaForcedSources(region, None, visit_time)
         else:
-            apdb.getDiaForcedSources(region, None, visit_time)
+            res = apdb.getDiaForcedSources(region, None, visit_time)
             self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
     def test_empty_gets_0months(self) -> None:

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -128,9 +128,6 @@ class ApdbTest(TestCaseMixin, ABC):
     enable_replica: bool = False
     """Set to true when support for replication is configured"""
 
-    allow_visit_query: bool = True
-    """Set to true when contains is implemented"""
-
     schema_path: str
     """Location of the Felis schema file."""
 
@@ -250,12 +247,8 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        if self.allow_visit_query:
-            res = apdb.containsVisitDetector(visit=1, detector=1)
-            self.assertFalse(res)
-        else:
-            with self.assertRaises(NotImplementedError):
-                apdb.containsVisitDetector(visit=0, detector=0)
+        res = apdb.containsVisitDetector(visit=1, detector=1)
+        self.assertFalse(res)
 
         # get sources by region
         if self.fsrc_requires_id_list:
@@ -295,14 +288,9 @@ class ApdbTest(TestCaseMixin, ABC):
         res = apdb.getDiaForcedSources(region, [], visit_time)
         self.assertIs(res, None)
 
-        # test if a visit has objects/sources
-        if self.allow_visit_query:
-            # Database is empty, no images exist.
-            res = apdb.containsVisitDetector(visit=1, detector=1)
-            self.assertFalse(res)
-        else:
-            with self.assertRaises(NotImplementedError):
-                apdb.containsVisitDetector(visit=0, detector=0)
+        # Database is empty, no images exist.
+        res = apdb.containsVisitDetector(visit=1, detector=1)
+        self.assertFalse(res)
 
     def test_storeObjects(self) -> None:
         """Store and retrieve DiaObjects."""
@@ -368,15 +356,11 @@ class ApdbTest(TestCaseMixin, ABC):
 
         # test if a visit is present
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        if self.allow_visit_query:
-            res = apdb.containsVisitDetector(visit=1, detector=1)
-            self.assertTrue(res)
-            # non-existent image
-            res = apdb.containsVisitDetector(visit=2, detector=42)
-            self.assertFalse(res)
-        else:
-            with self.assertRaises(NotImplementedError):
-                apdb.containsVisitDetector(visit=0, detector=0)
+        res = apdb.containsVisitDetector(visit=1, detector=1)
+        self.assertTrue(res)
+        # non-existent image
+        res = apdb.containsVisitDetector(visit=2, detector=42)
+        self.assertFalse(res)
 
     def test_storeForcedSources(self) -> None:
         """Store and retrieve DiaForcedSources."""
@@ -402,15 +386,11 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        if self.allow_visit_query:
-            res = apdb.containsVisitDetector(visit=1, detector=1)
-            self.assertTrue(res)
-            # non-existent image
-            res = apdb.containsVisitDetector(visit=2, detector=42)
-            self.assertFalse(res)
-        else:
-            with self.assertRaises(NotImplementedError):
-                apdb.containsVisitDetector(visit=0, detector=0)
+        res = apdb.containsVisitDetector(visit=1, detector=1)
+        self.assertTrue(res)
+        # non-existent image
+        res = apdb.containsVisitDetector(visit=2, detector=42)
+        self.assertFalse(res)
 
     def test_getChunks(self) -> None:
         """Store and retrieve replica chunks."""

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -107,7 +107,7 @@ class ApdbCassandraMixin:
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     """A test case for ApdbCassandra class"""
 
-    allow_visit_query = False
+    allow_visit_query = True
     time_partition_tables = False
     time_partition_start: str | None = None
     time_partition_end: str | None = None

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -107,7 +107,6 @@ class ApdbCassandraMixin:
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     """A test case for ApdbCassandra class"""
 
-    allow_visit_query = True
     time_partition_tables = False
     time_partition_start: str | None = None
     time_partition_end: str | None = None


### PR DESCRIPTION
This implementation is inefficient as it does a full scan of the tables (which may also affect performace of other clients). If performance becomes an issue we may need to reimplement it using a separate dedicated table.