### PR TITLE
DM-44619: Always use ra/dec columns for spatial indexing

### DIFF
--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -136,7 +136,7 @@ class ApdbTest(TestCaseMixin, ABC):
         ApdbTables.DiaObject: 8,
         ApdbTables.DiaObjectLast: 5,
         ApdbTables.DiaSource: 11,
-        ApdbTables.DiaForcedSource: 5,
+        ApdbTables.DiaForcedSource: 7,
         ApdbTables.SSObject: 3,
     }
 

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -188,6 +188,8 @@ def makeForcedSourceCatalog(
             "diaObjectId": objects["diaObjectId"],
             "visit": numpy.full(nrows, visit, dtype=numpy.int64),
             "detector": numpy.full(nrows, detector, dtype=numpy.int16),
+            "ra": objects["ra"],
+            "dec": objects["dec"],
             "midpointMjdTai": numpy.full(nrows, midpointMjdTai, dtype=numpy.float64),
             "flags": numpy.full(nrows, 0, dtype=numpy.int64),
         }

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -10,13 +10,11 @@ tables:
   - name: name
     "@id": "#metadata.name"
     datatype: text
-    length: 1024
     nullable: false
     description: Name or key for a metadata item.
   - name: value
     "@id": "#metadata.value"
     datatype: text
-    length: 65535
     nullable: false
     description: Content of the metadata item in string representation.
   primaryKey: "#metadata.name"
@@ -35,14 +33,12 @@ tables:
   - name: validityStart
     "@id": "#DiaObject.validityStart"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Time when validity of this diaObject starts.
     mysql:datatype: DATETIME
   - name: validityEnd
     "@id": "#DiaObject.validityEnd"
     datatype: timestamp
-    length: 6
     nullable: true
     description: Time when validity of this diaObject ends.
     mysql:datatype: DATETIME
@@ -70,7 +66,6 @@ tables:
   - name: lastNonForcedSource
     "@id": "#DiaObject.lastNonForcedSource"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Last time when non-forced DIASource was seen for this object.
     mysql:datatype: DATETIME
@@ -183,7 +178,6 @@ tables:
   - name: ssObjectReassocTime
     "@id": "#DiaSource.ssObjectReassocTime"
     datatype: timestamp
-    length: 6
     description: Time when this diaSource was reassociated from diaObject to ssObject
       (if such reassociation happens, otherwise NULL).
     mysql:datatype: DATETIME
@@ -229,6 +223,20 @@ tables:
     nullable: false
     mysql:datatype: BIGINT
     ivoa:ucd: meta.id;src
+  - name: ra
+    "@id": "#DiaForcedSource.ra"
+    datatype: double
+    nullable: false
+    description: Right ascension coordinate of the position of the DiaObject at time radecMjdTai.
+    ivoa:ucd: pos.eq.ra
+    fits:tunit: deg
+  - name: dec
+    "@id": "#DiaForcedSource.dec"
+    datatype: double
+    nullable: false
+    description: Declination coordinate of the position of the DiaObject at time radecMjdTai.
+    ivoa:ucd: pos.eq.dec
+    fits:tunit: deg
   - name: visit
     "@id": "#DiaForcedSource.visit"
     datatype: long
@@ -326,7 +334,6 @@ tables:
   - name: lastNonForcedSource
     "@id": "#DiaObjectLast.lastNonForcedSource"
     datatype: timestamp
-    length: 6
     nullable: false
     description: Last time when non-forced DIASource was seen for this object.
     mysql:datatype: DATETIME

--- a/tests/test_apdbSqlSchema.py
+++ b/tests/test_apdbSqlSchema.py
@@ -48,7 +48,7 @@ class ApdbSchemaTestCase(unittest.TestCase):
         ApdbTables.DiaObject: 8,
         ApdbTables.DiaObjectLast: 5,
         ApdbTables.DiaSource: 11,
-        ApdbTables.DiaForcedSource: 5,
+        ApdbTables.DiaForcedSource: 7,
         ApdbTables.SSObject: 3,
         ApdbTables.metadata: 2,
     }


### PR DESCRIPTION
DiaForcedSource table now defined ra/dec columns so that they can
be used to calculate partitioning index in Cassandra. DiaSource
table partitioning used a matching DiaObject partition index (and
spatial index in SQL). It is switched to always use DiaSource ra/dec
to make things uniform across all tables.