### PR TITLE
DM-44822: Add CLI commands to list and delete Cassandra instances

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
+    rev: 24.4.2
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.4
+    rev: v0.4.9
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -39,6 +39,8 @@ def main(args: Sequence[str] | None = None) -> None:
     subparsers = parser.add_subparsers(title="available subcommands", required=True)
     _create_sql_subcommand(subparsers)
     _create_cassandra_subcommand(subparsers)
+    _list_cassandra_subcommand(subparsers)
+    _delete_cassandra_subcommand(subparsers)
     _list_index_subcommand(subparsers)
     _metadata_subcommand(subparsers)
 
@@ -76,6 +78,26 @@ def _create_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None
         "--drop", help="If True then drop existing tables.", default=False, action="store_true"
     )
     parser.set_defaults(method=scripts.create_cassandra)
+
+
+def _list_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("list-cassandra", help="List APDB instances in Cassandra cluster.")
+    parser.add_argument("host", help="One of the host names for Cassandra cluster.")
+    parser.set_defaults(method=scripts.list_cassandra)
+
+
+def _delete_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("delete-cassandra", help="Delete APDB instance from Cassandra cluster.")
+    parser.add_argument("host", help="One of the host names for Cassandra cluster.")
+    parser.add_argument("keyspace", help="Cassandra keyspace name for APDB tables.")
+    parser.add_argument(
+        "-y",
+        "--confirm",
+        help="Assume 'yes' answer for confirmation.",
+        default=False,
+        action="store_true",
+    )
+    parser.set_defaults(method=scripts.delete_cassandra)
 
 
 def _list_index_subcommand(subparsers: argparse._SubParsersAction) -> None:

--- a/python/lsst/dax/apdb/cli/logging_cli.py
+++ b/python/lsst/dax/apdb/cli/logging_cli.py
@@ -53,7 +53,8 @@ class LoggingCli:
     def process_args(self, args: argparse.Namespace) -> None:
         """Configure Python logging based on command line options."""
         global_level = logging.INFO
-        logger_levels: dict[str, int] = {}
+        # Suppress chatty cassandra.cluster logger by default.
+        logger_levels: dict[str, int] = {"cassandra.cluster": logging.WARNING}
         for level_str in args.log_level:
             for spec in level_str.split(","):
                 logger_name, sep, level_name = spec.rpartition("=")

--- a/python/lsst/dax/apdb/scripts/delete_cassandra.py
+++ b/python/lsst/dax/apdb/scripts/delete_cassandra.py
@@ -19,9 +19,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .create_cassandra import create_cassandra
-from .create_sql import create_sql
-from .delete_cassandra import delete_cassandra
-from .list_cassandra import list_cassandra
-from .list_index import list_index
-from .metadata import metadata_delete, metadata_get, metadata_set, metadata_show
+from __future__ import annotations
+
+__all__ = ["delete_cassandra"]
+
+from ..cassandra import ApdbCassandra
+
+
+def delete_cassandra(host: str, keyspace: str, confirm: bool) -> None:
+    """Delete APDB instance from Cassandra cluster.
+
+    Parameters
+    ----------
+    host : `str`
+        Name of one of the hosts in Cassandra cluster.
+    keyspace : `str`
+        Cassandra keyspace name containing APDB tables.
+    confirm : `bool`
+        If True do not ask for confirmation.
+    """
+    if not confirm:
+        try:
+            answer = input(f"Type 'yes' to confirm deletion of keyspace {keyspace!r} and all of its data: ")
+            if answer != "yes":
+                return
+        except EOFError:
+            return
+    ApdbCassandra.delete_database(host=host, keyspace=keyspace)

--- a/python/lsst/dax/apdb/scripts/list_cassandra.py
+++ b/python/lsst/dax/apdb/scripts/list_cassandra.py
@@ -19,9 +19,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .create_cassandra import create_cassandra
-from .create_sql import create_sql
-from .delete_cassandra import delete_cassandra
-from .list_cassandra import list_cassandra
-from .list_index import list_index
-from .metadata import metadata_delete, metadata_get, metadata_set, metadata_show
+from __future__ import annotations
+
+__all__ = ["list_cassandra"]
+
+from ..cassandra import ApdbCassandra
+
+
+def list_cassandra(host: str) -> None:
+    """List APDB instances in Cassandra cluster.
+
+    Parameters
+    ----------
+    host : `str`
+        Name of one of the hosts in Cassandra cluster.
+    """
+    databases = ApdbCassandra.list_databases(host=host)
+    for database in sorted(databases):
+        print(database)

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -100,8 +100,7 @@ class ApdbCassandraMixin:
 
     def tearDown(self) -> None:
         # Delete per-test keyspace.
-        query = f"DROP KEYSPACE {self.keyspace}"
-        self._run_query(query)
+        ApdbCassandra.delete_database(self.cluster_host, self.keyspace)
 
 
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):


### PR DESCRIPTION
ApdbCassandra adds two class methods to list keyspaces in the cluster and delete keyspaces. Two CLI sub-commands also added that use these new methods.