### PR TITLE
DM-45233: Avoid storing tombstones in Cassandra

### DIFF
--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -152,6 +152,7 @@ def makeSourceCatalog(
             "dec": objects["dec"],
             "midpointMjdTai": numpy.full(nrows, midpointMjdTai, dtype=numpy.float64),
             "flags": numpy.full(nrows, 0, dtype=numpy.int64),
+            "ssObjectId": None,
         }
     )
     return df


### PR DESCRIPTION
Instead of sending None to insert queries, replace it with a special UNSET_VALUE which skips writing those values completely.