### PR TITLE
DM-44902: Extend list-cassandra command to print role names

### DIFF
--- a/doc/lsst.dax.apdb/index.rst
+++ b/doc/lsst.dax.apdb/index.rst
@@ -40,7 +40,13 @@ The name of the CLI script is ``apdb-cli`` and it has a number of subcommands:
 
   - ``create-cassandra`` is used to create new APDB instances based on Cassandra storage technology.
 
+  - ``list-cassandra`` command lists the names of APDB keyspaces and associated accounts for a specified Cassandra cluster.
+
+  - ``delete-cassandra`` drops an existing APDB instance from a Cassandra cluster.
+
   - ``list-index`` dumps the contents of the APDB index file.
+
+  - ``metadata`` provides support for operations on APDB metadata table.
 
 Each sub-command provides command line help describing its arguments.
 

--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 __all__ = ["ApdbCassandraConfig", "ApdbCassandra"]
 
-import dataclasses
-import json
 import logging
 from collections.abc import Iterable, Iterator, Mapping, Set
 from typing import TYPE_CHECKING, Any, cast
@@ -176,57 +174,6 @@ class ApdbCassandraConfig(ApdbConfig):
             "(DiaObjectsChunks has the same data)."
         ),
     )
-
-
-@dataclasses.dataclass
-class _FrozenApdbCassandraConfig:
-    """Part of the configuration that is saved in metadata table and read back.
-
-    The attributes are a subset of attributes in `ApdbCassandraConfig` class.
-
-    Parameters
-    ----------
-    config : `ApdbSqlConfig`
-        Configuration used to copy initial values of attributes.
-    """
-
-    use_insert_id: bool
-    part_pixelization: str
-    part_pix_level: int
-    ra_dec_columns: list[str]
-    time_partition_tables: bool
-    time_partition_days: int
-    use_insert_id_skips_diaobjects: bool
-
-    def __init__(self, config: ApdbCassandraConfig):
-        self.use_insert_id = config.use_insert_id
-        self.part_pixelization = config.part_pixelization
-        self.part_pix_level = config.part_pix_level
-        self.ra_dec_columns = list(config.ra_dec_columns)
-        self.time_partition_tables = config.time_partition_tables
-        self.time_partition_days = config.time_partition_days
-        self.use_insert_id_skips_diaobjects = config.use_insert_id_skips_diaobjects
-
-    def to_json(self) -> str:
-        """Convert this instance to JSON representation."""
-        return json.dumps(dataclasses.asdict(self))
-
-    def update(self, json_str: str) -> None:
-        """Update attribute values from a JSON string.
-
-        Parameters
-        ----------
-        json_str : str
-            String containing JSON representation of configuration.
-        """
-        data = json.loads(json_str)
-        if not isinstance(data, dict):
-            raise TypeError(f"JSON string must be convertible to object: {json_str!r}")
-        allowed_names = {field.name for field in dataclasses.fields(self)}
-        for key, value in data.items():
-            if key not in allowed_names:
-                raise ValueError(f"JSON object contains unknown key: {key}")
-            setattr(self, key, value)
 
 
 if CASSANDRA_IMPORTED:

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -83,6 +83,13 @@ def _create_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None
 def _list_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None:
     parser = subparsers.add_parser("list-cassandra", help="List APDB instances in Cassandra cluster.")
     parser.add_argument("host", help="One of the host names for Cassandra cluster.")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Provide detailed output.",
+        default=False,
+        action="store_true",
+    )
     parser.set_defaults(method=scripts.list_cassandra)
 
 

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -86,7 +86,7 @@ def _list_cassandra_subcommand(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "-v",
         "--verbose",
-        help="Provide detailed output.",
+        help="Provide full list of roles and associated permissions.",
         default=False,
         action="store_true",
     )

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -100,6 +100,7 @@ class ApdbCassandraMixin:
 
     def tearDown(self) -> None:
         # Delete per-test keyspace.
+        assert self.cluster_host is not None
         ApdbCassandra.delete_database(self.cluster_host, self.keyspace)
 
 


### PR DESCRIPTION
Role names is the only useful info that I could extract from Cassandra
using CQL. It would be nice to have data size, but CQL does not have
that info.

Note that the role executing this command needs SELECT permissions
for `system_auth.role_permissions` table (have to be granted for every new role).