### PR TITLE
DM-45668: Convert timestamps to naive type on return from queries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.2
+    rev: v0.6.1
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -49,7 +49,7 @@ _LOG = logging.getLogger(__name__)
 _dtype_map: Mapping[felis.datamodel.DataType | ExtraDataTypes, type | str] = {
     felis.datamodel.DataType.double: numpy.float64,
     felis.datamodel.DataType.float: numpy.float32,
-    felis.datamodel.DataType.timestamp: "datetime64[ms]",
+    felis.datamodel.DataType.timestamp: "datetime64[ns]",
     felis.datamodel.DataType.long: numpy.int64,
     felis.datamodel.DataType.int: numpy.int32,
     felis.datamodel.DataType.short: numpy.int16,

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -135,8 +135,8 @@ class ApdbTest(TestCaseMixin, ABC):
     table_column_count = {
         ApdbTables.DiaObject: 8,
         ApdbTables.DiaObjectLast: 5,
-        ApdbTables.DiaSource: 11,
-        ApdbTables.DiaForcedSource: 7,
+        ApdbTables.DiaSource: 12,
+        ApdbTables.DiaForcedSource: 8,
         ApdbTables.SSObject: 3,
     }
 

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import datetime
 import random
 from collections.abc import Iterator
 from typing import Any
@@ -141,6 +142,9 @@ def makeSourceCatalog(
     """
     nrows = len(objects)
     midpointMjdTai = visit_time.mjd
+    # Note that for now we use naive datetime for time_processed, to have it
+    # consistent with ap_association.
+    time_processed = datetime.datetime.now()
     df = pandas.DataFrame(
         {
             "diaSourceId": numpy.arange(start_id, start_id + nrows, dtype=numpy.int64),
@@ -153,6 +157,7 @@ def makeSourceCatalog(
             "midpointMjdTai": numpy.full(nrows, midpointMjdTai, dtype=numpy.float64),
             "flags": numpy.full(nrows, 0, dtype=numpy.int64),
             "ssObjectId": None,
+            "time_processed": time_processed,
         }
     )
     return df
@@ -184,6 +189,9 @@ def makeForcedSourceCatalog(
     """
     nrows = len(objects)
     midpointMjdTai = visit_time.mjd
+    # Note that for now we use naive datetime for time_processed, to have it
+    # consistent with ap_association.
+    time_processed = datetime.datetime.now()
     df = pandas.DataFrame(
         {
             "diaObjectId": objects["diaObjectId"],
@@ -193,6 +201,7 @@ def makeForcedSourceCatalog(
             "dec": objects["dec"],
             "midpointMjdTai": numpy.full(nrows, midpointMjdTai, dtype=numpy.float64),
             "flags": numpy.full(nrows, 0, dtype=numpy.int64),
+            "time_processed": time_processed,
         }
     )
     return df

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -197,6 +197,11 @@ tables:
     value: 0
     mysql:datatype: BIGINT
     ivoa:ucd: meta.code
+  - name: time_processed
+    "@id": "#DiaSource.time_processed"
+    datatype: timestamp
+    nullable: false
+    description: Time when the image was processed and this DiaSource record was generated.
   primaryKey: "#DiaSource.diaSourceId"
   indexes:
   - name: IDX_DiaSource_visitDetector
@@ -265,6 +270,11 @@ tables:
     value: 0
     mysql:datatype: BIGINT
     ivoa:ucd: meta.code
+  - name: time_processed
+    "@id": "#DiaForcedSource.time_processed"
+    datatype: timestamp
+    nullable: false
+    description: Time when this record was generated.
   primaryKey:
   - "#DiaForcedSource.diaObjectId"
   - "#DiaForcedSource.visit"

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -110,6 +110,9 @@ class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     time_partition_tables = False
     time_partition_start: str | None = None
     time_partition_end: str | None = None
+    # Cassandra stores timestamps with millisecond precision internally,
+    # but pandas seem to convert them to nanosecond type.
+    timestamp_type_name = "datetime64[ns]"
 
     def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -50,6 +50,7 @@ class ApdbSQLiteTestCase(ApdbTest, unittest.TestCase):
     fsrc_requires_id_list = True
     dia_object_index = "baseline"
     schema_path = TEST_SCHEMA
+    timestamp_type_name = "datetime64[ns]"
 
     def setUp(self) -> None:
         self.tempdir = tempfile.mkdtemp()
@@ -109,6 +110,7 @@ class ApdbPostgresTestCase(ApdbTest, unittest.TestCase):
     postgresql: Any
     enable_replica = True
     schema_path = TEST_SCHEMA
+    timestamp_type_name = "datetime64[ns]"
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/test_apdbSqlSchema.py
+++ b/tests/test_apdbSqlSchema.py
@@ -47,8 +47,8 @@ class ApdbSchemaTestCase(unittest.TestCase):
     table_column_count = {
         ApdbTables.DiaObject: 8,
         ApdbTables.DiaObjectLast: 5,
-        ApdbTables.DiaSource: 11,
-        ApdbTables.DiaForcedSource: 7,
+        ApdbTables.DiaSource: 12,
+        ApdbTables.DiaForcedSource: 8,
         ApdbTables.SSObject: 3,
         ApdbTables.metadata: 2,
     }


### PR DESCRIPTION
Apdb could return naive or timezone-aware timestamps in DataFrames from queries depending on backend type. AP pipelines expect (and create new DataFrames) containing naive types. To keep things consistent, Apdb will now convert timezone-aware timestamp columns to naive. Unit test added to verify expected behavior.