### PR TITLE
DM-45915: Fix handling of timezones for input timestamps.

### DIFF
--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -45,7 +45,9 @@ _LOG = logging.getLogger(__name__)
 
 # In most cases column types are determined by Cassandra driver, but in some
 # cases we need to create Pandas Dataframe ourselves and we use this map to
-# infer types of columns from their YAML schema.
+# infer types of columns from their YAML schema. Note that Cassandra saves
+# timestamps with millisecond precision, but pandas maps datetime type to
+# "datetime64[ns]".
 _dtype_map: Mapping[felis.datamodel.DataType | ExtraDataTypes, type | str] = {
     felis.datamodel.DataType.double: numpy.float64,
     felis.datamodel.DataType.float: numpy.float32,

--- a/python/lsst/dax/apdb/cassandra/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra/cassandra_utils.py
@@ -278,7 +278,7 @@ def literal(v: Any) -> Any:
     if v is None:
         pass
     elif isinstance(v, datetime):
-        v = int((v - datetime(1970, 1, 1)) / timedelta(seconds=1)) * 1000
+        v = int((v - datetime(1970, 1, 1)) / timedelta(seconds=1) * 1000)
     elif isinstance(v, (bytes, str, UUID, int)):
         pass
     else:

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -1018,7 +1018,7 @@ class ApdbSql(Apdb):
             if "lastNonForcedSource" in last_objs.columns:
                 # lastNonForcedSource is defined NOT NULL, fill it with visit
                 # time just in case.
-                last_objs["lastNonForcedSource"].fillna(dt, inplace=True)
+                last_objs.fillna({"lastNonForcedSource": dt}, inplace=True)
             else:
                 extra_column = pandas.Series([dt] * len(objs), name="lastNonForcedSource")
                 last_objs.set_index(extra_column.index, inplace=True)
@@ -1068,7 +1068,7 @@ class ApdbSql(Apdb):
         if "lastNonForcedSource" in objs.columns:
             # lastNonForcedSource is defined NOT NULL, fill it with visit time
             # just in case.
-            objs["lastNonForcedSource"] = objs["lastNonForcedSource"].fillna(dt)
+            objs.fillna({"lastNonForcedSource": dt}, inplace=True)
         else:
             extra_columns.append(pandas.Series([dt] * len(objs), name="lastNonForcedSource"))
         if extra_columns:

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -406,6 +406,9 @@ class ApdbTest(TestCaseMixin, ABC):
 
         # have to store Objects first
         time_before = datetime.datetime.now()
+        # Cassandra has a millisecond precision, so subtract 1ms to allow for
+        # truncated returned values.
+        time_before -= datetime.timedelta(milliseconds=1)
         objects = makeObjectCatalog(region, 100, visit_time)
         oids = list(objects["diaObjectId"])
         catalog = makeForcedSourceCatalog(objects, visit_time)

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -142,8 +142,9 @@ def makeSourceCatalog(
     """
     nrows = len(objects)
     midpointMjdTai = visit_time.mjd
-    # Note that for now we use naive datetime for time_processed, to have it
-    # consistent with ap_association.
+    # TODO: Note that for now we use naive datetime for time_processed, to have
+    # it consistent with ap_association, will need to update once we migrate
+    # to aware times everywhere.
     time_processed = datetime.datetime.now()
     df = pandas.DataFrame(
         {
@@ -189,8 +190,9 @@ def makeForcedSourceCatalog(
     """
     nrows = len(objects)
     midpointMjdTai = visit_time.mjd
-    # Note that for now we use naive datetime for time_processed, to have it
-    # consistent with ap_association.
+    # TODO: Note that for now we use naive datetime for time_processed, to have
+    # it consistent with ap_association, will need to update once we migrate
+    # to aware times everywhere.
     time_processed = datetime.datetime.now()
     df = pandas.DataFrame(
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ pandas
 pydantic
 pyyaml >= 5.1
 sqlalchemy
+testing.postgresql
+psycopg2
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-resources[s3] @ git+https://github.com/lsst/resources@main
 lsst-sphgeom @ git+https://github.com/lsst/sphgeom@main


### PR DESCRIPTION
If Postgres server timezone is set to something then UTC we
need to add UTC timezone to input timestamps so that server
does not try to convert them to server timezone. I also added
check for input timestamps with timezones, and convert them
to UTC as well (this may not be necessary, just to be safe).

Improve timestamp handling for Cassandra, fixed truncation bug.
If input timestamps are aware then convert them to UTC and drop
timezone. Cassandra does not need timezone info if input is in UTC.
On return Cassandra makes naive time (in UTC), so no conversion is
necessary. There was a bug in converting timestamps to milliseconds
that dropped fractional part, this is now fixed.