### PR TITLE
DM-46077: Add protection against extra slashes in sqlite URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.1
+    rev: v0.6.3
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/schema_model.py
+++ b/python/lsst/dax/apdb/schema_model.py
@@ -277,7 +277,7 @@ class Constraint:
                 ),
             )
         else:
-            raise TypeError(f"Unexpected constraint type: {dm_constr.type}")
+            raise TypeError(f"Unexpected constraint type: {dm_constr}")
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
SQLite complains when extra slashes appear at the start of URL,
but the error message is not quite comprehensible. To avoid triggering
that error the code now sanitizes URL before passing it to sqlalchemy.
