### PR TITLE
Add apdb-cli command line script to project config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ license-files = ["COPYRIGHT", "LICENSE"]
 [tool.setuptools.dynamic]
 version = { attr = "lsst_versions.get_lsst_version" }
 
+[project.scripts]
+apdb-cli = "lsst.dax.apdb.cli.apdb_cli:main"
+
 [tool.black]
 line-length = 110
 target-version = ["py311"]


### PR DESCRIPTION
This just adds the `apdb-cli` as a command line script to the project so that it is automatically installed when running `pip`.