### PR TITLE
DM-45646: Improve handling of moving DiaObjects in Cassandra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.7
+    rev: v0.6.9
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -94,6 +94,9 @@ class ExtraTables(enum.Enum):
     DiaSourceToPartition = "DiaSourceToPartition"
     "Maps diaSourceId to its partition values (pixel and time)."
 
+    DiaObjectLastToPartition = "DiaObjectLastToPartition"
+    "Maps last diaObjectId version to its partition (pixel)."
+
     def table_name(self, prefix: str = "") -> str:
         """Return full table name."""
         return prefix + self.value
@@ -276,6 +279,27 @@ class ApdbCassandraSchema(ApdbSchema):
             indexes=[],
             constraints=[],
             annotations={"cassandra:partitioning_columns": ["diaSourceId"]},
+        )
+
+        # This table maps diaObjectId to its partition in DiaObjectLast table.
+        extra_tables[ExtraTables.DiaObjectLastToPartition] = schema_model.Table(
+            id="#" + ExtraTables.DiaObjectLastToPartition.value,
+            name=ExtraTables.DiaObjectLastToPartition.table_name(self._prefix),
+            columns=[
+                schema_model.Column(
+                    id="#diaObjectId",
+                    name="diaObjectId",
+                    datatype=felis.datamodel.DataType.long,
+                    nullable=False,
+                ),
+                schema_model.Column(
+                    id="#apdb_part", name="apdb_part", datatype=felis.datamodel.DataType.long, nullable=False
+                ),
+            ],
+            primary_key=[],
+            indexes=[],
+            constraints=[],
+            annotations={"cassandra:partitioning_columns": ["diaObjectId"]},
         )
 
         replica_chunk_column = schema_model.Column(

--- a/python/lsst/dax/apdb/cassandra/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra/cassandra_utils.py
@@ -188,7 +188,7 @@ def select_concurrent(
     ep = session.get_execution_profile(execution_profile)
     if ep.row_factory is raw_data_factory:
         # Collect rows into a single list and build Dataframe out of that
-        _LOG.debug("making pandas data frame out of rows/columns")
+        _LOG.debug("making raw data out of rows/columns")
         table_data: ApdbCassandraTableData | None = None
         for success, result in results:
             if success:

--- a/python/lsst/dax/apdb/cassandra/cassandra_utils.py
+++ b/python/lsst/dax/apdb/cassandra/cassandra_utils.py
@@ -43,7 +43,7 @@ import pandas
 # If cassandra-driver is not there the module can still be imported
 # but things will not work.
 try:
-    from cassandra.cluster import EXEC_PROFILE_DEFAULT, Session
+    from cassandra.cluster import Session
     from cassandra.concurrent import execute_concurrent
     from cassandra.query import PreparedStatement
 
@@ -54,39 +54,6 @@ except ImportError:
 from ..apdbReplica import ApdbTableData
 
 _LOG = logging.getLogger(__name__)
-
-
-if CASSANDRA_IMPORTED:
-
-    class SessionWrapper:
-        """Special wrapper class to workaround ``execute_concurrent()`` issue
-        which does not allow non-default execution profile.
-
-        Instance of this class can be passed to execute_concurrent() instead
-        of `Session` instance. This class implements a small set of methods
-        that are needed by ``execute_concurrent()``. When
-        ``execute_concurrent()`` is fixed to accept exectution profiles, this
-        wrapper can be dropped.
-        """
-
-        def __init__(self, session: Session, execution_profile: Any = EXEC_PROFILE_DEFAULT):
-            self._session = session
-            self._execution_profile = execution_profile
-
-        def execute_async(
-            self,
-            *args: Any,
-            execution_profile: Any = EXEC_PROFILE_DEFAULT,
-            **kwargs: Any,
-        ) -> Any:
-            # explicit parameter can override our settings
-            if execution_profile is EXEC_PROFILE_DEFAULT:
-                execution_profile = self._execution_profile
-            return self._session.execute_async(*args, execution_profile=execution_profile, **kwargs)
-
-        def submit(self, *args: Any, **kwargs: Any) -> Any:
-            # internal method
-            return self._session.submit(*args, **kwargs)
 
 
 class ApdbCassandraTableData(ApdbTableData):
@@ -209,13 +176,13 @@ def select_concurrent(
     This method can raise any exception that is raised by one of the provided
     statements.
     """
-    session_wrap = SessionWrapper(session, execution_profile)
     results = execute_concurrent(
-        session_wrap,
+        session,
         statements,
         results_generator=True,
         raise_on_first_error=False,
         concurrency=concurrency,
+        execution_profile=execution_profile,
     )
 
     ep = session.get_execution_profile(execution_profile)

--- a/python/lsst/dax/apdb/tests/data_factory.py
+++ b/python/lsst/dax/apdb/tests/data_factory.py
@@ -63,14 +63,14 @@ def _genPointsInRegion(region: Region, count: int) -> Iterator[LonLat]:
 
 
 def makeObjectCatalog(
-    region: Region, count: int, visit_time: astropy.time.Time, *, start_id: int = 1, **kwargs: Any
+    region: Region | LonLat, count: int, visit_time: astropy.time.Time, *, start_id: int = 1, **kwargs: Any
 ) -> pandas.DataFrame:
     """Make a catalog containing a bunch of DiaObjects inside a region.
 
     Parameters
     ----------
-    region : `lsst.sphgeom.Region`
-        Spherical region.
+    region : `lsst.sphgeom.Region` or `lsst.sphgeom.LonLat`
+        Spherical region or spherical coordinate.
     count : `int`
         Number of records to generate.
     visit_time : `astropy.time.Time`
@@ -90,7 +90,10 @@ def makeObjectCatalog(
     Returned catalog only contains three columns - ``diaObjectId`, ``ra``, and
     ``dec`` (in degrees).
     """
-    points = list(_genPointsInRegion(region, count))
+    if isinstance(region, Region):
+        points = list(_genPointsInRegion(region, count))
+    else:
+        points = [region] * count
     # diaObjectId=0 may be used in some code for DiaSource foreign key to mean
     # the same as ``None``.
     ids = numpy.arange(start_id, len(points) + start_id, dtype=numpy.int64)

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -51,6 +51,7 @@ except ImportError:
 import lsst.utils.tests
 from lsst.dax.apdb import ApdbConfig, ApdbTables
 from lsst.dax.apdb.cassandra import ApdbCassandra, ApdbCassandraConfig
+from lsst.dax.apdb.pixelization import Pixelization
 from lsst.dax.apdb.tests import ApdbSchemaUpdateTest, ApdbTest
 
 TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
@@ -102,6 +103,11 @@ class ApdbCassandraMixin:
         # Delete per-test keyspace.
         assert self.cluster_host is not None
         ApdbCassandra.delete_database(self.cluster_host, self.keyspace)
+
+    def pixelization(self, config: ApdbConfig) -> Pixelization:
+        """Return pixelization used by implementation."""
+        assert isinstance(config, ApdbCassandraConfig), "Only expect ApdbCassandraConfig here"
+        return Pixelization(config.part_pixelization, config.part_pix_level, config.part_pix_max_ranges)
 
 
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):


### PR DESCRIPTION
This patch adds one more internal table which tracks spatial partitions
for DiaObjects in the DiaObjectLast table. The code compares new
partitions with old and deletes records from DiaObjectLast which change
their partition before saving them.