### PR TITLE
DM-29588: Cast timeout parameter to integer for postgres/mysql

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,9 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 keywords = ["lsst"]

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -298,7 +298,7 @@ class ApdbSql(Apdb):
             if config.db_url.startswith("sqlite"):
                 conn_args.update(timeout=config.connection_timeout)
             elif config.db_url.startswith(("postgresql", "mysql")):
-                conn_args.update(connect_timeout=config.connection_timeout)
+                conn_args.update(connect_timeout=int(config.connection_timeout))
         kw.update(connect_args=conn_args)
         engine = sqlalchemy.create_engine(cls._connection_url(config.db_url, create=create), **kw)
 


### PR DESCRIPTION
Config specifies `connection_timeout` as float, and float is accepted
by sqlite driver, but postgres and mysql expect integer instead
and raise exceptions if float is passed.