### PR TITLE
DM-48391: Add options to limit the size of batch queries in Cassandra

### DIFF
--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -668,3 +668,25 @@ class ApdbCassandraSchema(ApdbSchema):
         else:
             table_schema = self._extra_tables[table]
         return table_schema
+
+    def table_row_size(self, table: ApdbTables | ExtraTables) -> int:
+        """Return an estimate of the row size of a given table.
+
+        Parameters
+        ----------
+        table : `ApdbTables` or `ExtraTables`
+
+        Returns
+        -------
+        size : `int`
+            An estimate of a table row size.
+
+        Notes
+        -----
+        Returned size is not exact. When table has variable-size columns (e.g.
+        strings) may be incorrect. Stored data size or wire-level protocol size
+        can be smaller if some columns are not set or set to NULL.
+        """
+        table_schema = self._table_schema(table)
+        size = sum(column.size() for column in table_schema.columns)
+        return size

--- a/python/lsst/dax/apdb/cassandra/config.py
+++ b/python/lsst/dax/apdb/cassandra/config.py
@@ -218,6 +218,23 @@ class ApdbCassandraConfig(ApdbConfig):
         ),
     )
 
+    batch_statement_limit: int = Field(
+        default=65_535,
+        description=(
+            "Limit on a number of rows in a BatchStatement. "
+            "Default is the same as Cassandra limit of 65535."
+        ),
+    )
+
+    batch_size_limit: int = Field(
+        default=1_000_000,
+        description=(
+            "Limit on a size of BatchStatement in bytes. Batch size is estimated approximately. "
+            "Set to 0 or negative to disable this limit. "
+            "Server-side batch size warning threshold needs to be set to at least this value."
+        ),
+    )
+
     @field_validator("ra_dec_columns")
     @classmethod
     def check_ra_dec(cls, v: Iterable[str]) -> tuple[str, str]:

--- a/python/lsst/dax/apdb/schema_model.py
+++ b/python/lsst/dax/apdb/schema_model.py
@@ -66,6 +66,24 @@ def _make_iterable(obj: str | Iterable[str]) -> Iterable[str]:
         yield from obj
 
 
+_data_type_size: Mapping[DataTypes, int] = {
+    felis.datamodel.DataType.boolean: 1,
+    felis.datamodel.DataType.byte: 1,
+    felis.datamodel.DataType.short: 2,
+    felis.datamodel.DataType.int: 4,
+    felis.datamodel.DataType.long: 8,
+    felis.datamodel.DataType.float: 4,
+    felis.datamodel.DataType.double: 8,
+    felis.datamodel.DataType.char: 1,
+    felis.datamodel.DataType.string: 2,  # approximation, depends on character set
+    felis.datamodel.DataType.unicode: 2,  # approximation, depends on character set
+    felis.datamodel.DataType.text: 2,  # approximation, depends on character set
+    felis.datamodel.DataType.binary: 1,
+    felis.datamodel.DataType.timestamp: 8,  # May be different depending on backend
+    ExtraDataTypes.UUID: 16,
+}
+
+
 @dataclasses.dataclass
 class Column:
     """Column representation in schema."""
@@ -133,6 +151,21 @@ class Column:
     def clone(self) -> Column:
         """Make a clone of self."""
         return dataclasses.replace(self, table=None)
+
+    def size(self) -> int:
+        """Return size in bytes of this column.
+
+        Returns
+        -------
+        size : `int`
+            Size in bytes for this column, typically represents in-memory size
+            of the corresponding data type. May or may not be the same as
+            storage size or wire-level protocol size.
+        """
+        size = _data_type_size[self.datatype]
+        if self.length is not None:
+            size *= self.length
+        return size
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
ApdbCassandra configuration adds options to limit the number of rows in batch queries and the size of the batch queries. This includes fixing the error related to 64k limit of the batch queries for updates of DiaObjectLastToPartition table. There are still some batch queries that do not check the limits, but those are not likely to exceed Cassandra limits.