### PR TITLE
DM-49135: Cast numpy.float type to float for sqlalchemy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12
   - repo: https://github.com/pycqa/isort
     rev: 6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.3
+    rev: v0.9.7
     hooks:
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ apdb-cli = "lsst.dax.apdb.cli.apdb_cli:main"
 
 [tool.black]
 line-length = 110
-target-version = ["py311"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"
@@ -77,7 +77,7 @@ write_to = "python/lsst/dax/apdb/version.py"
 
 [tool.ruff]
 line-length = 110
-target-version = "py311"
+target-version = "py312"
 exclude = [
     "__init__.py",
     "config/apdb-cassandra.py",

--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -741,7 +741,7 @@ class ApdbCassandra(Apdb):
         months = self.config.read_sources_months
         if months == 0:
             return None
-        mjd_end = visit_time.mjd
+        mjd_end = float(visit_time.mjd)
         mjd_start = mjd_end - months * 30
 
         return self._getSources(region, object_ids, mjd_start, mjd_end, ApdbTables.DiaSource)
@@ -753,7 +753,7 @@ class ApdbCassandra(Apdb):
         months = self.config.read_forced_sources_months
         if months == 0:
             return None
-        mjd_end = visit_time.mjd
+        mjd_end = float(visit_time.mjd)
         mjd_start = mjd_end - months * 30
 
         return self._getSources(region, object_ids, mjd_start, mjd_end, ApdbTables.DiaForcedSource)

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -101,7 +101,7 @@ def _make_midpointMjdTai_start(visit_time: astropy.time.Time, months: int) -> fl
     """
     # TODO: Use of MJD must be consistent with the code in ap_association
     # (see DM-31996)
-    return visit_time.mjd - months * 30
+    return float(visit_time.mjd - months * 30)
 
 
 def _onSqlite3Connect(


### PR DESCRIPTION
This fixes Postgres backend problem with np.float in the rendered query.
Cassandra handled that correctly, but I added a cast there as well, for
uniformity.