### PR TITLE
DM-49327: Improve performance of containsVisitDetector method

### DIFF
--- a/python/lsst/dax/apdb/apdb.py
+++ b/python/lsst/dax/apdb/apdb.py
@@ -204,7 +204,13 @@ class Apdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def containsVisitDetector(self, visit: int, detector: int) -> bool:
+    def containsVisitDetector(
+        self,
+        visit: int,
+        detector: int,
+        region: Region,
+        visit_time: astropy.time.Time,
+    ) -> bool:
         """Test whether any sources for a given visit-detector are present in
         the APDB.
 
@@ -212,6 +218,11 @@ class Apdb(ABC):
         ----------
         visit, detector : `int`
             The ID of the visit-detector to search for.
+        region : `lsst.sphgeom.Region`
+            Region corresponding to the visit/detector combination.
+        visit_time : `astropy.time.Time`
+            Visit time (as opposed to visit processing time). This can be any
+            timestamp in the visit timespan, e.g. its begin or end time.
 
         Returns
         -------

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -603,7 +603,13 @@ class ApdbSql(Apdb):
         _LOG.debug("found %s DiaForcedSources", len(sources))
         return sources
 
-    def containsVisitDetector(self, visit: int, detector: int) -> bool:
+    def containsVisitDetector(
+        self,
+        visit: int,
+        detector: int,
+        region: Region,
+        visit_time: astropy.time.Time,
+    ) -> bool:
         # docstring is inherited from a base class
         src_table: sqlalchemy.schema.Table = self._schema.get_table(ApdbTables.DiaSource)
         frcsrc_table: sqlalchemy.schema.Table = self._schema.get_table(ApdbTables.DiaForcedSource)

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -65,7 +65,7 @@ else:
 def _make_region(xyz: tuple[float, float, float] = (1.0, 1.0, -1.0)) -> Region:
     """Make a region to use in tests"""
     pointing_v = UnitVector3d(*xyz)
-    fov = 0.05  # radians
+    fov = 0.0013  # radians
     region = Circle(pointing_v, Angle(fov / 2))
     return region
 
@@ -257,7 +257,7 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        res = apdb.containsVisitDetector(visit=1, detector=1)
+        res = apdb.containsVisitDetector(visit=1, detector=1, region=region, visit_time=visit_time)
         self.assertFalse(res)
 
         # get sources by region
@@ -299,7 +299,7 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assertIs(res, None)
 
         # Database is empty, no images exist.
-        res = apdb.containsVisitDetector(visit=1, detector=1)
+        res = apdb.containsVisitDetector(visit=1, detector=1, region=region, visit_time=visit_time)
         self.assertFalse(res)
 
     def test_storeObjects(self) -> None:
@@ -400,10 +400,10 @@ class ApdbTest(TestCaseMixin, ABC):
 
         # test if a visit is present
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        res = apdb.containsVisitDetector(visit=1, detector=1)
+        res = apdb.containsVisitDetector(visit=1, detector=1, region=region, visit_time=visit_time)
         self.assertTrue(res)
         # non-existent image
-        res = apdb.containsVisitDetector(visit=2, detector=42)
+        res = apdb.containsVisitDetector(visit=2, detector=42, region=region, visit_time=visit_time)
         self.assertFalse(res)
 
     def test_storeForcedSources(self) -> None:
@@ -430,10 +430,10 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assert_catalog(res, 0, ApdbTables.DiaForcedSource)
 
         # data_factory's ccdVisitId generation corresponds to (1, 1)
-        res = apdb.containsVisitDetector(visit=1, detector=1)
+        res = apdb.containsVisitDetector(visit=1, detector=1, region=region, visit_time=visit_time)
         self.assertTrue(res)
         # non-existent image
-        res = apdb.containsVisitDetector(visit=2, detector=42)
+        res = apdb.containsVisitDetector(visit=2, detector=42, region=region, visit_time=visit_time)
         self.assertFalse(res)
 
     def test_timestamps(self) -> None:


### PR DESCRIPTION
Avoids full scan of of the source tables to determine if visit/detector are present. The method now requires region and time interval which enables use of partitioning key (but not full primary key).