### PR TITLE
DM-49455: Fix float dataset type use in SQL backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.12
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.7
+    rev: v0.9.10
     hooks:
       - id: ruff

--- a/python/lsst/dax/apdb/cli/options.py
+++ b/python/lsst/dax/apdb/cli/options.py
@@ -103,7 +103,9 @@ def cassandra_config_options(parser: argparse.ArgumentParser) -> None:
     _option_from_pydantic_field(group, ApdbCassandraConnectionConfig, "port", metavar="PORT")
     _option_from_pydantic_field(group, ApdbCassandraConnectionConfig, "username", metavar="USER")
     _option_from_pydantic_field(group, ApdbCassandraConfig, "prefix")
-    group.add_argument("--replication-factor", help="Replication factor used when creating new keyspace.")
+    group.add_argument(
+        "--replication-factor", help="Replication factor used when creating new keyspace.", type=int
+    )
     group.add_argument(
         "--table-options", help="Path or URI of YAML file containing table options.", metavar="URI"
     )

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -69,7 +69,7 @@ _LOG = logging.getLogger(__name__)
 
 _MON = MonAgent(__name__)
 
-VERSION = VersionTuple(0, 1, 1)
+VERSION = VersionTuple(0, 1, 2)
 """Version for the code controlling non-replication tables. This needs to be
 updated following compatibility rules when schema produced by this code
 changes.

--- a/python/lsst/dax/apdb/sql/modelToSql.py
+++ b/python/lsst/dax/apdb/sql/modelToSql.py
@@ -109,7 +109,7 @@ class ModelToSql:
         # Map model column types to SQLAlchemy.
         self._type_map: dict[felis.datamodel.DataType | schema_model.ExtraDataTypes, type] = {
             felis.datamodel.DataType.double: sqlalchemy.types.Double,
-            felis.datamodel.DataType.float: sqlalchemy.types.Float,
+            felis.datamodel.DataType.float: sqlalchemy.types.REAL,
             felis.datamodel.DataType.timestamp: sqlalchemy.types.TIMESTAMP,
             felis.datamodel.DataType.long: sqlalchemy.types.BigInteger,
             felis.datamodel.DataType.int: sqlalchemy.types.Integer,


### PR DESCRIPTION
Postgres backend rendered `sqlalchemy.Float` type as double precision,
resulting in all float columns to be 64-bit types. This patch switches
to `sqlalchemy.REAL` type instead. It increments patch for ApdbSql
version, migration script is implemented on the same branch.