### PR TITLE
DM-50093: Add sub-chunk column to replica chunk tables

### DIFF
--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -25,6 +25,7 @@ __all__ = ["ApdbCassandra"]
 
 import dataclasses
 import logging
+import random
 import warnings
 from collections.abc import Iterable, Iterator, Mapping, Set
 from typing import TYPE_CHECKING, Any, cast
@@ -174,6 +175,7 @@ class ApdbCassandra(Apdb):
         "enable_replica",
         "ra_dec_columns",
         "replica_skips_diaobjects",
+        "replica_sub_chunk_count",
         "partitioning.part_pixelization",
         "partitioning.part_pix_level",
         "partitioning.time_partition_tables",
@@ -207,6 +209,19 @@ class ApdbCassandra(Apdb):
             else:
                 self.config = config
 
+        # Read versions stored in database.
+        self._db_versions = self._readVersions(self._metadata)
+        _LOG.debug("Database versions: %s", self._db_versions)
+
+        # Since replica version 1.1.0 we use finer partitioning for replica
+        # chunk tables.
+        self._has_chunk_sub_partitions = False
+        if self.config.enable_replica:
+            assert self._db_versions.replica_version is not None, "Replica version must be defined"
+            self._has_chunk_sub_partitions = ApdbCassandraReplica.hasChunkSubPartitions(
+                self._db_versions.replica_version
+            )
+
         self._pixelization = Pixelization(
             self.config.partitioning.part_pixelization,
             self.config.partitioning.part_pix_level,
@@ -221,19 +236,34 @@ class ApdbCassandra(Apdb):
             prefix=self.config.prefix,
             time_partition_tables=self.config.partitioning.time_partition_tables,
             enable_replica=self.config.enable_replica,
+            has_chunk_sub_partitions=self._has_chunk_sub_partitions,
         )
         self._partition_zero_epoch_mjd = float(self.partition_zero_epoch.mjd)
 
-        self._db_versions: _DbVersions | None = None
-        with self._timer("version_check"):
-            self._db_versions = self._versionCheck(self._metadata)
+        current_versions = _DbVersions(
+            schema_version=self._schema.schemaVersion(),
+            code_version=self.apdbImplementationVersion(),
+            replica_version=(
+                ApdbCassandraReplica.apdbReplicaImplementationVersion()
+                if self.config.enable_replica
+                else None
+            ),
+        )
+        _LOG.debug("Current versions: %s", current_versions)
+        self._versionCheck(current_versions, self._db_versions)
+
+        # Since replica version 1.1.0 we use finer partitioning for replica
+        # chunk tables.
+        self._has_chunk_sub_partitions = False
+        if self.config.enable_replica:
+            assert self._db_versions.replica_version is not None, "Replica version must be defined"
+            self._has_chunk_sub_partitions = ApdbCassandraReplica.hasChunkSubPartitions(
+                self._db_versions.replica_version
+            )
 
         # Support for DiaObjectLastToPartition was added at code version 0.1.1
         # in a backward-compatible way (we only use the table if it is there).
-        if self._db_versions:
-            self._has_dia_object_last_to_partition = self._db_versions.code_version >= VersionTuple(0, 1, 1)
-        else:
-            self._has_dia_object_last_to_partition = False
+        self._has_dia_object_last_to_partition = self._db_versions.code_version >= VersionTuple(0, 1, 1)
 
         # Cache for prepared statements
         self._preparer = PreparedStatementCache(self._session)
@@ -316,10 +346,10 @@ class ApdbCassandra(Apdb):
 
         return None
 
-    def _versionCheck(self, metadata: ApdbMetadataCassandra) -> _DbVersions:
+    def _readVersions(self, metadata: ApdbMetadataCassandra) -> _DbVersions:
         """Check schema version compatibility."""
 
-        def _get_version(key: str, default: VersionTuple) -> VersionTuple:
+        def _get_version(key: str) -> VersionTuple:
             """Retrieve version number from given metadata key."""
             version_str = metadata.get(key)
             if version_str is None:
@@ -327,39 +357,46 @@ class ApdbCassandra(Apdb):
                 raise RuntimeError(f"Version key {key!r} does not exist in metadata table.")
             return VersionTuple.fromString(version_str)
 
-        # For old databases where metadata table does not exist we assume that
-        # version of both code and schema is 0.1.0.
-        initial_version = VersionTuple(0, 1, 0)
-        db_schema_version = _get_version(self.metadataSchemaVersionKey, initial_version)
-        db_code_version = _get_version(self.metadataCodeVersionKey, initial_version)
-
-        # For now there is no way to make read-only APDB instances, assume that
-        # any access can do updates.
-        if not self._schema.schemaVersion().checkCompatibility(db_schema_version):
-            raise IncompatibleVersionError(
-                f"Configured schema version {self._schema.schemaVersion()} "
-                f"is not compatible with database version {db_schema_version}"
-            )
-        if not self.apdbImplementationVersion().checkCompatibility(db_code_version):
-            raise IncompatibleVersionError(
-                f"Current code version {self.apdbImplementationVersion()} "
-                f"is not compatible with database version {db_code_version}"
-            )
+        db_schema_version = _get_version(self.metadataSchemaVersionKey)
+        db_code_version = _get_version(self.metadataCodeVersionKey)
 
         # Check replica code version only if replica is enabled.
         db_replica_version: VersionTuple | None = None
-        if self._schema.replication_enabled:
-            db_replica_version = _get_version(self.metadataReplicaVersionKey, initial_version)
-            code_replica_version = ApdbCassandraReplica.apdbReplicaImplementationVersion()
-            if not code_replica_version.checkCompatibility(db_replica_version):
-                raise IncompatibleVersionError(
-                    f"Current replication code version {code_replica_version} "
-                    f"is not compatible with database version {db_replica_version}"
-                )
+        if self.config.enable_replica:
+            db_replica_version = _get_version(self.metadataReplicaVersionKey)
 
         return _DbVersions(
             schema_version=db_schema_version, code_version=db_code_version, replica_version=db_replica_version
         )
+
+    def _versionCheck(self, current_versions: _DbVersions, db_versions: _DbVersions) -> None:
+        """Check schema version compatibility."""
+        if not current_versions.schema_version.checkCompatibility(db_versions.schema_version):
+            raise IncompatibleVersionError(
+                f"Configured schema version {current_versions.schema_version} "
+                f"is not compatible with database version {db_versions.schema_version}"
+            )
+        if not current_versions.code_version.checkCompatibility(db_versions.code_version):
+            raise IncompatibleVersionError(
+                f"Current code version {current_versions.code_version} "
+                f"is not compatible with database version {db_versions.code_version}"
+            )
+
+        # Check replica code version only if replica is enabled.
+        match current_versions.replica_version, db_versions.replica_version:
+            case None, None:
+                pass
+            case VersionTuple() as current, VersionTuple() as stored:
+                if not current.checkCompatibility(stored):
+                    raise IncompatibleVersionError(
+                        f"Current replication code version {current} "
+                        f"is not compatible with database version {stored}"
+                    )
+            case _:
+                raise IncompatibleVersionError(
+                    f"Current replication code version {current_versions.replica_version} "
+                    f"is not compatible with database version {db_versions.replica_version}"
+                )
 
     @classmethod
     def apdbImplementationVersion(cls) -> VersionTuple:
@@ -836,13 +873,13 @@ class ApdbCassandra(Apdb):
         objects = self._add_apdb_part(objects)
         self._storeDiaObjects(objects, visit_time, replica_chunk)
 
-        if sources is not None:
+        if sources is not None and len(sources) > 0:
             # copy apdb_part column from DiaObjects to DiaSources
             sources = self._add_apdb_part(sources)
-            self._storeDiaSources(ApdbTables.DiaSource, sources, replica_chunk)
-            self._storeDiaSourcesPartitions(sources, visit_time, replica_chunk)
+            subchunk = self._storeDiaSources(ApdbTables.DiaSource, sources, replica_chunk)
+            self._storeDiaSourcesPartitions(sources, visit_time, replica_chunk, subchunk)
 
-        if forced_sources is not None:
+        if forced_sources is not None and len(forced_sources) > 0:
             forced_sources = self._add_apdb_part(forced_sources)
             self._storeDiaSources(ApdbTables.DiaForcedSource, forced_sources, replica_chunk)
 
@@ -916,26 +953,9 @@ class ApdbCassandra(Apdb):
                 values = (ssObjectId, apdb_part, apdb_time_part, diaSourceId)
             queries.add(self._preparer.prepare(query), values)
 
-        # Reassign in replica tables, only if replication is enabled
+        # TODO: (DM-50190) Replication for updated records is not implemented.
         if id2chunk_id:
-            # Filter out chunks that have been deleted already. There is a
-            # potential race with concurrent removal of chunks, but it
-            # should be handled by WHERE in UPDATE.
-            known_ids = set()
-            if replica_chunks := self.get_replica().getReplicaChunks():
-                known_ids = set(replica_chunk.id for replica_chunk in replica_chunks)
-            id2chunk_id = {key: value for key, value in id2chunk_id.items() if value in known_ids}
-            if id2chunk_id:
-                table_name = self._schema.tableName(ExtraTables.DiaSourceChunks)
-                for diaSourceId, ssObjectId in idMap.items():
-                    if replica_chunk := id2chunk_id.get(diaSourceId):
-                        query = (
-                            f'UPDATE "{self._keyspace}"."{table_name}" '
-                            ' SET "ssObjectId" = ?, "diaObjectId" = NULL '
-                            'WHERE "apdb_replica_chunk" = ? AND "diaSourceId" = ?'
-                        )
-                        values = (ssObjectId, replica_chunk, diaSourceId)
-                        queries.add(self._preparer.prepare(query), values)
+            warnings.warn("Replication of reassigned DisSource records is not implemented.", stacklevel=2)
 
         _LOG.debug("%s: will update %d records", table_name, len(idMap))
         with self._timer("source_reassign_time") as timer:
@@ -1100,15 +1120,20 @@ class ApdbCassandra(Apdb):
         partition = 0
 
         table_name = self._schema.tableName(ExtraTables.ApdbReplicaChunks)
-        query = (
-            f'INSERT INTO "{self._keyspace}"."{table_name}" '
-            "(partition, apdb_replica_chunk, last_update_time, unique_id) "
-            "VALUES (?, ?, ?, ?)"
-        )
+
+        columns = ["partition", "apdb_replica_chunk", "last_update_time", "unique_id"]
+        values = [partition, replica_chunk.id, timestamp, replica_chunk.unique_id]
+        if self._has_chunk_sub_partitions:
+            columns.append("has_subchunks")
+            values.append(True)
+
+        column_list = ", ".join(columns)
+        placeholders = ",".join(["%s"] * len(columns))
+        query = f'INSERT INTO "{self._keyspace}"."{table_name}" ({column_list}) VALUES ({placeholders})'
 
         self._session.execute(
-            self._preparer.prepare(query),
-            (partition, replica_chunk.id, timestamp, replica_chunk.unique_id),
+            query,
+            values,
             timeout=self.config.connection_config.write_timeout,
             execution_profile="write",
         )
@@ -1232,14 +1257,21 @@ class ApdbCassandra(Apdb):
 
         if replica_chunk is not None:
             extra_columns = dict(apdb_replica_chunk=replica_chunk.id, validityStart=visit_time_dt)
-            self._storeObjectsPandas(objs, ExtraTables.DiaObjectChunks, extra_columns=extra_columns)
+            table = ExtraTables.DiaObjectChunks
+            if self._has_chunk_sub_partitions:
+                table = ExtraTables.DiaObjectChunks2
+                # Use a random number for a second part of partitioning key so
+                # that different clients could wrtite to different partitions.
+                # This makes it not exactly reproducible.
+                extra_columns["apdb_replica_subchunk"] = random.randrange(self.config.replica_sub_chunk_count)
+            self._storeObjectsPandas(objs, table, extra_columns=extra_columns)
 
     def _storeDiaSources(
         self,
         table_name: ApdbTables,
         sources: pandas.DataFrame,
         replica_chunk: ReplicaChunk | None,
-    ) -> None:
+    ) -> int | None:
         """Store catalog of DIASources or DIAForcedSources from current visit.
 
         Parameters
@@ -1252,6 +1284,12 @@ class ApdbCassandra(Apdb):
             Time of the current visit.
         replica_chunk : `ReplicaChunk` or `None`
             Replica chunk identifier if replication is configured.
+
+        Returns
+        -------
+        subchunk : `int` or `None`
+            Subchunk number for resulting replica data, `None` if relication is
+            not enabled ot subchunking is not enabled.
         """
         # Time partitioning has to be based on midpointMjdTai, not visit_time
         # as visit_time is not really a visit time.
@@ -1273,16 +1311,31 @@ class ApdbCassandra(Apdb):
                     sub_frame.drop(columns="apdb_time_part", inplace=True)
                     self._storeObjectsPandas(sub_frame, table_name, time_part=time_part)
 
+        subchunk: int | None = None
         if replica_chunk is not None:
             extra_columns = dict(apdb_replica_chunk=replica_chunk.id)
-            if table_name is ApdbTables.DiaSource:
-                extra_table = ExtraTables.DiaSourceChunks
+            if self._has_chunk_sub_partitions:
+                subchunk = random.randrange(self.config.replica_sub_chunk_count)
+                extra_columns["apdb_replica_subchunk"] = subchunk
+                if table_name is ApdbTables.DiaSource:
+                    extra_table = ExtraTables.DiaSourceChunks2
+                else:
+                    extra_table = ExtraTables.DiaForcedSourceChunks2
             else:
-                extra_table = ExtraTables.DiaForcedSourceChunks
+                if table_name is ApdbTables.DiaSource:
+                    extra_table = ExtraTables.DiaSourceChunks
+                else:
+                    extra_table = ExtraTables.DiaForcedSourceChunks
             self._storeObjectsPandas(sources, extra_table, extra_columns=extra_columns)
 
+        return subchunk
+
     def _storeDiaSourcesPartitions(
-        self, sources: pandas.DataFrame, visit_time: astropy.time.Time, replica_chunk: ReplicaChunk | None
+        self,
+        sources: pandas.DataFrame,
+        visit_time: astropy.time.Time,
+        replica_chunk: ReplicaChunk | None,
+        subchunk: int | None,
     ) -> None:
         """Store mapping of diaSourceId to its partitioning values.
 
@@ -1292,12 +1345,19 @@ class ApdbCassandra(Apdb):
             Catalog containing DiaSource records
         visit_time : `astropy.time.Time`
             Time of the current visit.
+        replica_chunk : `ReplicaChunk` or `None`
+            Replication chunk, or `None` when replication is disabled.
+        subchunk : `int` or `None`
+            Replication sub-chunk, or `None` when replication is disabled or
+            sub-chunking is not used.
         """
         id_map = cast(pandas.DataFrame, sources[["diaSourceId", "apdb_part"]])
         extra_columns = {
             "apdb_time_part": self._time_partition(visit_time),
             "apdb_replica_chunk": replica_chunk.id if replica_chunk is not None else None,
         }
+        if self._has_chunk_sub_partitions:
+            extra_columns["apdb_replica_subchunk"] = subchunk
 
         self._storeObjectsPandas(
             id_map, ExtraTables.DiaSourceToPartition, extra_columns=extra_columns, time_part=None

--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -348,7 +348,7 @@ class ApdbCassandra(Apdb):
 
         # Check replica code version only if replica is enabled.
         db_replica_version: VersionTuple | None = None
-        if self._schema.has_replica_chunks:
+        if self._schema.replication_enabled:
             db_replica_version = _get_version(self.metadataReplicaVersionKey, initial_version)
             code_replica_version = ApdbCassandraReplica.apdbReplicaImplementationVersion()
             if not code_replica_version.checkCompatibility(db_replica_version):
@@ -828,7 +828,7 @@ class ApdbCassandra(Apdb):
             forced_sources = self._fix_input_timestamps(forced_sources)
 
         replica_chunk: ReplicaChunk | None = None
-        if self._schema.has_replica_chunks:
+        if self._schema.replication_enabled:
             replica_chunk = ReplicaChunk.make_replica_chunk(visit_time, self.config.replica_chunk_seconds)
             self._storeReplicaChunk(replica_chunk, visit_time)
 

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -28,14 +28,14 @@ from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
 import astropy.time
-from lsst.utils.iteration import chunk_iterable
 
 from ..apdbReplica import ApdbReplica, ApdbTableData, ReplicaChunk
+from ..apdbSchema import ApdbTables
 from ..monitor import MonAgent
 from ..timer import Timer
 from ..versionTuple import VersionTuple
 from .apdbCassandraSchema import ApdbCassandraSchema, ExtraTables
-from .cassandra_utils import ApdbCassandraTableData, PreparedStatementCache
+from .cassandra_utils import PreparedStatementCache, execute_concurrent, select_concurrent
 
 if TYPE_CHECKING:
     from .apdbCassandra import ApdbCassandra
@@ -44,7 +44,7 @@ _LOG = logging.getLogger(__name__)
 
 _MON = MonAgent(__name__)
 
-VERSION = VersionTuple(1, 0, 0)
+VERSION = VersionTuple(1, 1, 0)
 """Version for the code controlling replication tables. This needs to be
 updated following compatibility rules when schema produced by this code
 changes.
@@ -84,6 +84,11 @@ class ApdbCassandraReplica(ApdbReplica):
         # Docstring inherited from base class.
         return VERSION
 
+    @classmethod
+    def hasChunkSubPartitions(cls, version: VersionTuple) -> bool:
+        """Return True if replica chunk tables have sub-partitions."""
+        return version >= VersionTuple(1, 1, 0)
+
     def getReplicaChunks(self) -> list[ReplicaChunk] | None:
         # docstring is inherited from a base class
         if not self._schema.replication_enabled:
@@ -96,12 +101,12 @@ class ApdbCassandraReplica(ApdbReplica):
         # We want to avoid timezone mess so return timestamps as milliseconds.
         query = (
             "SELECT toUnixTimestamp(last_update_time), apdb_replica_chunk, unique_id "
-            f'FROM "{self._config.keyspace}"."{table_name}" WHERE partition = ?'
+            f'FROM "{self._config.keyspace}"."{table_name}" WHERE partition = %s'
         )
 
         with self._timer("chunks_select_time") as timer:
             result = self._session.execute(
-                self._preparer.prepare(query),
+                query,
                 (partition,),
                 timeout=self._config.connection_config.read_timeout,
                 execution_profile="read_tuples",
@@ -123,79 +128,109 @@ class ApdbCassandraReplica(ApdbReplica):
         if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
-        # There is 64k limit on number of markers in Cassandra CQL
-        for chunk_ids in chunk_iterable(chunks, 20_000):
-            chunk_list = list(chunk_ids)
-            params = ",".join("?" * len(chunk_ids))
+        # everything goes into a single partition
+        partition = 0
 
-            # everything goes into a single partition
-            partition = 0
+        # Iterable can be single pass, make everything that we need from it
+        # in a single loop.
+        repl_table_params = []
+        chunk_table_params: list[tuple] = []
+        for chunk in chunks:
+            repl_table_params.append((partition, chunk))
+            if self._schema.has_chunk_sub_partitions:
+                for subchunk in range(self._config.replica_sub_chunk_count):
+                    chunk_table_params.append((chunk, subchunk))
+            else:
+                chunk_table_params.append((chunk,))
+        # Anything to do att all?
+        if not repl_table_params:
+            return
 
-            table_name = self._schema.tableName(ExtraTables.ApdbReplicaChunks)
-            query = (
-                f'DELETE FROM "{self._config.keyspace}"."{table_name}" '
-                f"WHERE partition = ? AND apdb_replica_chunk IN ({params})"
-            )
+        table_name = self._schema.tableName(ExtraTables.ApdbReplicaChunks)
+        query = (
+            f'DELETE FROM "{self._config.keyspace}"."{table_name}" '
+            f"WHERE partition = ? AND apdb_replica_chunk = ?"
+        )
+        statement = self._preparer.prepare(query)
 
-            with self._timer("chunks_delete_time") as timer:
-                self._session.execute(
-                    self._preparer.prepare(query),
-                    [partition] + chunk_list,
-                    timeout=self._config.connection_config.remove_timeout,
-                )
-                timer.add_values(row_count=len(chunk_list))
+        queries = [(statement, param) for param in repl_table_params]
+        with self._timer("chunks_delete_time") as timer:
+            execute_concurrent(self._session, queries)
+            timer.add_values(row_count=len(queries))
 
-            # Also remove those chunk_ids from Dia*Chunks tables.
-            for table in (
-                ExtraTables.DiaObjectChunks,
-                ExtraTables.DiaSourceChunks,
-                ExtraTables.DiaForcedSourceChunks,
-            ):
-                table_name = self._schema.tableName(table)
-                query = (
-                    f'DELETE FROM "{self._config.keyspace}"."{table_name}"'
-                    f" WHERE apdb_replica_chunk IN ({params})"
-                )
-                with self._timer("table_chunk_detele_time", tags={"table": table_name}) as timer:
-                    self._session.execute(
-                        self._preparer.prepare(query),
-                        chunk_list,
-                        timeout=self._config.connection_config.remove_timeout,
-                    )
-                    timer.add_values(row_count=len(chunk_list))
+        # Also remove those chunk_ids from Dia*Chunks tables.
+        tables = list(ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions).values())
+        for table in tables:
+            table_name = self._schema.tableName(table)
+            query = f'DELETE FROM "{self._config.keyspace}"."{table_name}" WHERE apdb_replica_chunk = ?'
+            if self._schema.has_chunk_sub_partitions:
+                query += " AND apdb_replica_subchunk = ?"
+            statement = self._preparer.prepare(query)
+
+            queries = [(statement, param) for param in chunk_table_params]
+            with self._timer("table_chunk_detele_time", tags={"table": table_name}) as timer:
+                execute_concurrent(self._session, queries)
+                timer.add_values(row_count=len(queries))
 
     def getDiaObjectsChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        return self._get_chunks(ExtraTables.DiaObjectChunks, chunks)
+        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[ApdbTables.DiaObject]
+        return self._get_chunks(table, chunks)
 
     def getDiaSourcesChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        return self._get_chunks(ExtraTables.DiaSourceChunks, chunks)
+        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[ApdbTables.DiaSource]
+        return self._get_chunks(table, chunks)
 
     def getDiaForcedSourcesChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        return self._get_chunks(ExtraTables.DiaForcedSourceChunks, chunks)
+        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[
+            ApdbTables.DiaForcedSource
+        ]
+        return self._get_chunks(table, chunks)
 
     def _get_chunks(self, table: ExtraTables, chunks: Iterable[int]) -> ApdbTableData:
         """Return records from a particular table given set of insert IDs."""
         if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
-        # We do not expect too may chunks in this query.
-        chunks = list(chunks)
-        params = ",".join("?" * len(chunks))
+        # NOTE: if an existing database is migrated and has both types of chunk
+        # tables (e.g. DiaObjectChunks and DiaObjectChunks2) it is possible
+        # that the same chunk can appear in both tables. In reality schema
+        # migration should only happen during the downtime, so there will be
+        # suffient gap and a different chunk ID will be used for new chunks.
 
         table_name = self._schema.tableName(table)
         # I know that chunk table schema has only regular APDB columns plus
         # apdb_replica_chunk column, and this is exactly what we need to return
         # from this method, so selecting a star is fine here.
-        query = (
-            f'SELECT * FROM "{self._config.keyspace}"."{table_name}" WHERE apdb_replica_chunk IN ({params})'
-        )
+        query = f'SELECT * FROM "{self._config.keyspace}"."{table_name}" WHERE apdb_replica_chunk = ?'
+        if self._schema.has_chunk_sub_partitions:
+            query += " AND apdb_replica_subchunk = ?"
         statement = self._preparer.prepare(query)
 
+        queries: list[tuple] = []
+        if self._schema.has_chunk_sub_partitions:
+            for chunk in chunks:
+                for subchunk in range(self._config.replica_sub_chunk_count):
+                    queries.append((statement, (chunk, subchunk)))
+            if not queries:
+                # Add a dummy query to return correct set of columns.
+                queries.append((statement, (-1, -1)))
+        else:
+            for chunk in chunks:
+                queries.append((statement, (chunk,)))
+            if not queries:
+                # Add a dummy query to return correct set of columns.
+                queries.append((statement, (-1,)))
+
         with self._timer("table_chunk_select_time", tags={"table": table_name}) as timer:
-            result = self._session.execute(statement, chunks, execution_profile="read_raw")
-            table_data = cast(ApdbCassandraTableData, result._current_rows)
+            table_data = cast(
+                ApdbTableData,
+                select_concurrent(
+                    self._session, queries, "read_raw_multi", self._config.connection_config.read_concurrency
+                ),
+            )
             timer.add_values(row_count=len(table_data.rows()))
+
         return table_data

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -276,7 +276,7 @@ class ApdbCassandraReplica(ApdbReplica):
                 queries = []
                 for chunk in chunks:
                     if not has_chunk_sub_partitions.get(chunk, True):
-                        queries.append((statement, (chunk)))
+                        queries.append((statement, (chunk,)))
                 if not queries and not table_data_subchunk:
                     # Add a dummy query to return correct set of columns.
                     queries.append((statement, (-1,)))

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -86,7 +86,7 @@ class ApdbCassandraReplica(ApdbReplica):
 
     def getReplicaChunks(self) -> list[ReplicaChunk] | None:
         # docstring is inherited from a base class
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             return None
 
         # everything goes into a single partition
@@ -120,7 +120,7 @@ class ApdbCassandraReplica(ApdbReplica):
 
     def deleteReplicaChunks(self, chunks: Iterable[int]) -> None:
         # docstring is inherited from a base class
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
         # There is 64k limit on number of markers in Cassandra CQL
@@ -178,7 +178,7 @@ class ApdbCassandraReplica(ApdbReplica):
 
     def _get_chunks(self, table: ExtraTables, chunks: Iterable[int]) -> ApdbTableData:
         """Return records from a particular table given set of insert IDs."""
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
         # We do not expect too may chunks in this query.

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -35,7 +35,12 @@ from ..monitor import MonAgent
 from ..timer import Timer
 from ..versionTuple import VersionTuple
 from .apdbCassandraSchema import ApdbCassandraSchema, ExtraTables
-from .cassandra_utils import PreparedStatementCache, execute_concurrent, select_concurrent
+from .cassandra_utils import (
+    ApdbCassandraTableData,
+    PreparedStatementCache,
+    execute_concurrent,
+    select_concurrent,
+)
 
 if TYPE_CHECKING:
     from .apdbCassandra import ApdbCassandra
@@ -174,25 +179,54 @@ class ApdbCassandraReplica(ApdbReplica):
 
     def getDiaObjectsChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[ApdbTables.DiaObject]
-        return self._get_chunks(table, chunks)
+        return self._get_chunks(ApdbTables.DiaObject, chunks)
 
     def getDiaSourcesChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[ApdbTables.DiaSource]
-        return self._get_chunks(table, chunks)
+        return self._get_chunks(ApdbTables.DiaSource, chunks)
 
     def getDiaForcedSourcesChunks(self, chunks: Iterable[int]) -> ApdbTableData:
         # docstring is inherited from a base class
-        table = ExtraTables.replica_chunk_tables(self._schema.has_chunk_sub_partitions)[
-            ApdbTables.DiaForcedSource
-        ]
-        return self._get_chunks(table, chunks)
+        return self._get_chunks(ApdbTables.DiaForcedSource, chunks)
 
-    def _get_chunks(self, table: ExtraTables, chunks: Iterable[int]) -> ApdbTableData:
+    def _get_chunks(self, table: ApdbTables, chunks: Iterable[int]) -> ApdbTableData:
         """Return records from a particular table given set of insert IDs."""
         if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
+
+        # We need to iterate few times.
+        chunks = list(chunks)
+
+        # If schema was migrated then a chunk can appear in either old or new
+        # chunk table (e.g. DiaObjectChunks or DiaObjectChunks2). Chunk table
+        # has a column which will be set to true for new table.
+        has_chunk_sub_partitions: dict[int, bool] = {}
+        if self._schema.has_chunk_sub_partitions:
+            table_name = self._schema.tableName(ExtraTables.ApdbReplicaChunks)
+            chunks_str = ",".join(str(chunk_id) for chunk_id in chunks)
+            query = (
+                f'SELECT apdb_replica_chunk, has_subchunks FROM "{self._config.keyspace}"."{table_name}" '
+                f"WHERE partition = %s and apdb_replica_chunk IN ({chunks_str})"
+            )
+            partition = 0
+            result = self._session.execute(
+                query,
+                (partition,),
+                timeout=self._config.connection_config.read_timeout,
+                execution_profile="read_tuples",
+            )
+            has_chunk_sub_partitions = {chunk_id: has_subchunk for chunk_id, has_subchunk in result}
+        else:
+            has_chunk_sub_partitions = {chunk_id: False for chunk_id in chunks}
+
+        # Check what kind of tables we want to query, if chunk list is empty
+        # then use tbales which should exist in the schema.
+        if has_chunk_sub_partitions:
+            have_subchunks = any(has_chunk_sub_partitions.values())
+            have_non_subchunks = not all(has_chunk_sub_partitions.values())
+        else:
+            have_subchunks = self._schema.has_chunk_sub_partitions
+            have_non_subchunks = not have_subchunks
 
         # NOTE: if an existing database is migrated and has both types of chunk
         # tables (e.g. DiaObjectChunks and DiaObjectChunks2) it is possible
@@ -200,37 +234,73 @@ class ApdbCassandraReplica(ApdbReplica):
         # migration should only happen during the downtime, so there will be
         # suffient gap and a different chunk ID will be used for new chunks.
 
-        table_name = self._schema.tableName(table)
-        # I know that chunk table schema has only regular APDB columns plus
-        # apdb_replica_chunk column, and this is exactly what we need to return
-        # from this method, so selecting a star is fine here.
-        query = f'SELECT * FROM "{self._config.keyspace}"."{table_name}" WHERE apdb_replica_chunk = ?'
-        if self._schema.has_chunk_sub_partitions:
-            query += " AND apdb_replica_subchunk = ?"
-        statement = self._preparer.prepare(query)
-
-        queries: list[tuple] = []
-        if self._schema.has_chunk_sub_partitions:
-            for chunk in chunks:
-                for subchunk in range(self._config.replica_sub_chunk_count):
-                    queries.append((statement, (chunk, subchunk)))
-            if not queries:
-                # Add a dummy query to return correct set of columns.
-                queries.append((statement, (-1, -1)))
-        else:
-            for chunk in chunks:
-                queries.append((statement, (chunk,)))
-            if not queries:
-                # Add a dummy query to return correct set of columns.
-                queries.append((statement, (-1,)))
+        table_data: ApdbCassandraTableData | None = None
+        table_data_subchunk: ApdbCassandraTableData | None = None
 
         with self._timer("table_chunk_select_time", tags={"table": table_name}) as timer:
-            table_data = cast(
-                ApdbTableData,
-                select_concurrent(
-                    self._session, queries, "read_raw_multi", self._config.connection_config.read_concurrency
-                ),
-            )
+            if have_subchunks:
+                replica_table = ExtraTables.replica_chunk_tables(True)[table]
+                table_name = self._schema.tableName(replica_table)
+                query = (
+                    f'SELECT * FROM "{self._config.keyspace}"."{table_name}" '
+                    "WHERE apdb_replica_chunk = ? AND apdb_replica_subchunk = ?"
+                )
+                statement = self._preparer.prepare(query)
+
+                queries: list[tuple] = []
+                for chunk in chunks:
+                    if has_chunk_sub_partitions.get(chunk, False):
+                        for subchunk in range(self._config.replica_sub_chunk_count):
+                            queries.append((statement, (chunk, subchunk)))
+                if not queries and not have_non_subchunks:
+                    # Add a dummy query to return correct set of columns.
+                    queries.append((statement, (-1, -1)))
+
+                if queries:
+                    table_data_subchunk = cast(
+                        ApdbCassandraTableData,
+                        select_concurrent(
+                            self._session,
+                            queries,
+                            "read_raw_multi",
+                            self._config.connection_config.read_concurrency,
+                        ),
+                    )
+
+            if have_non_subchunks:
+                replica_table = ExtraTables.replica_chunk_tables(False)[table]
+                table_name = self._schema.tableName(replica_table)
+                query = f'SELECT * FROM "{self._config.keyspace}"."{table_name}" WHERE apdb_replica_chunk = ?'
+                statement = self._preparer.prepare(query)
+
+                queries = []
+                for chunk in chunks:
+                    if not has_chunk_sub_partitions.get(chunk, True):
+                        queries.append((statement, (chunk)))
+                if not queries and not table_data_subchunk:
+                    # Add a dummy query to return correct set of columns.
+                    queries.append((statement, (-1,)))
+
+                if queries:
+                    table_data = cast(
+                        ApdbCassandraTableData,
+                        select_concurrent(
+                            self._session,
+                            queries,
+                            "read_raw_multi",
+                            self._config.connection_config.read_concurrency,
+                        ),
+                    )
+
+            # Merge if both are non-empty.
+            if table_data and table_data_subchunk:
+                table_data_subchunk.project(drop=["apdb_replica_subchunk"])
+                table_data.append(table_data_subchunk)
+            elif table_data_subchunk:
+                table_data = table_data_subchunk
+            elif not table_data:
+                raise AssertionError("above logic is incorrect")
+
             timer.add_values(row_count=len(table_data.rows()))
 
         return table_data

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -360,19 +360,9 @@ class ApdbCassandraSchema(ApdbSchema):
         return extra_tables
 
     @property
-    def has_replica_chunks(self) -> bool:
-        """Whether insert ID tables are to be used (`bool`)."""
-        if self._has_replica_chunks is None:
-            self._has_replica_chunks = self._enable_replica and self._check_replica_chunks()
-        return self._has_replica_chunks
-
-    def _check_replica_chunks(self) -> bool:
-        """Check whether database has tables for tracking insert IDs."""
-        table_name = ExtraTables.ApdbReplicaChunks.table_name(self._prefix)
-        query = "SELECT count(*) FROM system_schema.tables WHERE keyspace_name = %s and table_name = %s"
-        result = self._session.execute(query, (self._keyspace, table_name))
-        row = result.one()
-        return bool(row[0])
+    def replication_enabled(self) -> bool:
+        """True when replication is enabled (`bool`)."""
+        return self._enable_replica
 
     def empty(self) -> bool:
         """Return True if database schema is empty.

--- a/python/lsst/dax/apdb/cassandra/config.py
+++ b/python/lsst/dax/apdb/cassandra/config.py
@@ -217,6 +217,11 @@ class ApdbCassandraConfig(ApdbConfig):
         ),
     )
 
+    replica_sub_chunk_count: int = Field(
+        default=64,
+        description="Number of sub-partitions in replica chunk tables.",
+    )
+
     batch_statement_limit: int = Field(
         default=65_535,
         description=(

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -333,7 +333,7 @@ class ApdbSql(Apdb):
             )
 
         # Check replica code version only if replica is enabled.
-        if self._schema.has_replica_chunks:
+        if self._schema.replication_enabled:
             db_replica_version = _get_version(self.metadataReplicaVersionKey)
             code_replica_version = ApdbSqlReplica.apdbReplicaImplementationVersion()
             if not code_replica_version.checkCompatibility(db_replica_version):
@@ -644,7 +644,7 @@ class ApdbSql(Apdb):
         # We want to run all inserts in one transaction.
         with self._engine.begin() as connection:
             replica_chunk: ReplicaChunk | None = None
-            if self._schema.has_replica_chunks:
+            if self._schema.replication_enabled:
                 replica_chunk = ReplicaChunk.make_replica_chunk(visit_time, self.config.replica_chunk_seconds)
                 self._storeReplicaChunk(replica_chunk, visit_time, connection)
 

--- a/python/lsst/dax/apdb/sql/apdbSqlReplica.py
+++ b/python/lsst/dax/apdb/sql/apdbSqlReplica.py
@@ -101,11 +101,11 @@ class ApdbSqlReplica(ApdbReplica):
 
     def getReplicaChunks(self) -> list[ReplicaChunk] | None:
         # docstring is inherited from a base class
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             return None
 
         table = self._schema.get_table(ExtraTables.ApdbReplicaChunks)
-        assert table is not None, "has_replica_chunks=True means it must be defined"
+        assert table is not None, "replication_enabled=True means it must be defined"
         query = sql.select(
             table.columns["apdb_replica_chunk"], table.columns["last_update_time"], table.columns["unique_id"]
         ).order_by(table.columns["last_update_time"])
@@ -121,7 +121,7 @@ class ApdbSqlReplica(ApdbReplica):
 
     def deleteReplicaChunks(self, chunks: Iterable[int]) -> None:
         # docstring is inherited from a base class
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
         table = self._schema.get_table(ExtraTables.ApdbReplicaChunks)
@@ -154,7 +154,7 @@ class ApdbSqlReplica(ApdbReplica):
         """Return catalog of records for given insert identifiers, common
         implementation for all DIA tables.
         """
-        if not self._schema.has_replica_chunks:
+        if not self._schema.replication_enabled:
             raise ValueError("APDB is not configured for replication")
 
         table = self._schema.get_table(table_enum)

--- a/python/lsst/dax/apdb/sql/apdbSqlSchema.py
+++ b/python/lsst/dax/apdb/sql/apdbSqlSchema.py
@@ -89,7 +89,7 @@ class ApdbSqlSchema(ApdbSchema):
         DiaSource table instance
     forcedSources : `sqlalchemy.Table`
         DiaForcedSource table instance
-    has_replica_chunks : `bool`
+    replication_enabled : `bool`
         If true then schema has tables for replication chunks.
 
     Parameters
@@ -313,17 +313,9 @@ class ApdbSqlSchema(ApdbSchema):
         return [column for column in table.columns if column.name not in exclude_columns]
 
     @property
-    def has_replica_chunks(self) -> bool:
-        """Whether insert ID tables are to be used (`bool`)."""
-        if self._has_replica_chunks is None:
-            self._has_replica_chunks = self._enable_replica and self._check_replica_chunks()
-        return self._has_replica_chunks
-
-    def _check_replica_chunks(self) -> bool:
-        """Check whether database has tables for tracking insert IDs."""
-        inspector = sqlalchemy.inspect(self._engine)
-        db_tables = set(inspector.get_table_names(schema=self._metadata.schema))
-        return ExtraTables.ApdbReplicaChunks.table_name(self._prefix) in db_tables
+    def replication_enabled(self) -> bool:
+        """True if replication is enabled (`bool`)."""
+        return self._enable_replica
 
     def _make_apdb_tables(self, mysql_engine: str = "InnoDB") -> Mapping[ApdbTables, schema_model.Table]:
         """Generate schema for regular tables.

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -136,6 +136,9 @@ class ApdbTest(TestCaseMixin, ABC):
     timestamp_type_name: str
     """Type name of timestamp columns in DataFrames returned from queries."""
 
+    extra_chunk_columns = 1
+    """Number of additional columns in chunk tables."""
+
     # number of columns as defined in tests/config/schema.yaml
     table_column_count = {
         ApdbTables.DiaObject: 8,
@@ -194,7 +197,9 @@ class ApdbTest(TestCaseMixin, ABC):
         n_rows = sum(1 for row in catalog.rows())
         self.assertEqual(n_rows, rows)
         # One extra column for replica chunk id
-        self.assertEqual(len(catalog.column_names()), self.table_column_count[table] + 1)
+        self.assertEqual(
+            len(catalog.column_names()), self.table_column_count[table] + self.extra_chunk_columns
+        )
 
     def test_makeSchema(self) -> None:
         """Test for making APDB schema."""

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -123,6 +123,7 @@ class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     # Cassandra stores timestamps with millisecond precision internally,
     # but pandas seem to convert them to nanosecond type.
     timestamp_type_name = "datetime64[ns]"
+    extra_chunk_columns = 2
 
     def make_instance(self, **kwargs: Any) -> ApdbConfig:
         """Make config class instance used in all tests."""


### PR DESCRIPTION
This column is a part of the partitioning key and it is filled with
random numbers in reasonably narrow range. This aloows to distribute
writing of the chund data across many nodes in the cluster.
ApdbCassandraReplica version is updated to 1.1.0.

Verified to work OK with databases at 1.0.0 and 1.1.0.