### PR TITLE
DM-49202: Expose schema version in replication interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build.*
+build/
 *.egg-info
 .sconsign.dblite
 config.log

--- a/python/lsst/dax/apdb/apdbReplica.py
+++ b/python/lsst/dax/apdb/apdbReplica.py
@@ -161,12 +161,12 @@ class ApdbReplica(ABC):
 
     @abstractmethod
     def schemaVersion(self) -> VersionTuple:
-        """Return version number for current APDB schema.
+        """Return version number of the database schema.
 
         Returns
         -------
         version : `VersionTuple`
-            Version of the schema defined in APDB database.
+            Version of the database schema.
         """
         raise NotImplementedError()
 

--- a/python/lsst/dax/apdb/apdbReplica.py
+++ b/python/lsst/dax/apdb/apdbReplica.py
@@ -160,6 +160,17 @@ class ApdbReplica(ABC):
         raise NotImplementedError()
 
     @abstractmethod
+    def schemaVersion(self) -> VersionTuple:
+        """Return version number for current APDB schema.
+
+        Returns
+        -------
+        version : `VersionTuple`
+            Version of the schema defined in APDB database.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def getReplicaChunks(self) -> list[ReplicaChunk] | None:
         """Return collection of replication chunks known to the database.
 

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -86,7 +86,7 @@ class ApdbCassandraReplica(ApdbReplica):
 
     def schemaVersion(self) -> VersionTuple:
         # Docstring inherited from base class.
-        return self._schema.schemaVersion()
+        return self._apdb._db_versions.schema_version
 
     @classmethod
     def apdbReplicaImplementationVersion(cls) -> VersionTuple:

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraReplica.py
@@ -84,6 +84,10 @@ class ApdbCassandraReplica(ApdbReplica):
         """Create `Timer` instance given its name."""
         return Timer(name, _MON, tags=tags)
 
+    def schemaVersion(self) -> VersionTuple:
+        # Docstring inherited from base class.
+        return self._schema.schemaVersion()
+
     @classmethod
     def apdbReplicaImplementationVersion(cls) -> VersionTuple:
         # Docstring inherited from base class.

--- a/python/lsst/dax/apdb/sql/apdbSql.py
+++ b/python/lsst/dax/apdb/sql/apdbSql.py
@@ -173,7 +173,7 @@ class ApdbSql(Apdb):
             enable_replica=self.config.enable_replica,
         )
 
-        self._versionCheck(self._metadata)
+        self._db_schema_version = self._versionCheck(self._metadata)
 
         self.pixelator = HtmPixelization(self.config.pixelization.htm_level)
 
@@ -305,8 +305,10 @@ class ApdbSql(Apdb):
 
         return url_string
 
-    def _versionCheck(self, metadata: ApdbMetadataSql) -> None:
-        """Check schema version compatibility."""
+    def _versionCheck(self, metadata: ApdbMetadataSql) -> VersionTuple:
+        """Check schema version compatibility and return the database schema
+        version.
+        """
 
         def _get_version(key: str) -> VersionTuple:
             """Retrieve version number from given metadata key."""
@@ -341,6 +343,8 @@ class ApdbSql(Apdb):
                     f"Current replication code version {code_replica_version} "
                     f"is not compatible with database version {db_replica_version}"
                 )
+
+        return db_schema_version
 
     @classmethod
     def apdbImplementationVersion(cls) -> VersionTuple:
@@ -447,7 +451,7 @@ class ApdbSql(Apdb):
 
     def get_replica(self) -> ApdbSqlReplica:
         """Return `ApdbReplica` instance for this database."""
-        return ApdbSqlReplica(self._schema, self._engine)
+        return ApdbSqlReplica(self._schema, self._engine, self._db_schema_version)
 
     def tableRowCount(self) -> dict[str, int]:
         """Return dictionary with the table names and row counts.

--- a/python/lsst/dax/apdb/sql/apdbSqlReplica.py
+++ b/python/lsst/dax/apdb/sql/apdbSqlReplica.py
@@ -94,6 +94,10 @@ class ApdbSqlReplica(ApdbReplica):
         """Create `Timer` instance given its name."""
         return Timer(name, *self._timer_args, tags=tags)
 
+    def schemaVersion(self) -> VersionTuple:
+        # Docstring inherited from base class.
+        return self._schema.schemaVersion()
+
     @classmethod
     def apdbReplicaImplementationVersion(cls) -> VersionTuple:
         # Docstring inherited from base class.

--- a/python/lsst/dax/apdb/sql/apdbSqlReplica.py
+++ b/python/lsst/dax/apdb/sql/apdbSqlReplica.py
@@ -78,13 +78,22 @@ class ApdbSqlReplica(ApdbReplica):
         Instance of `ApdbSqlSchema` class for APDB database.
     engine : `sqlalchemy.engine.Engine`
         Engine for database access.
+    db_schema_version : `VersionTuple`
+        Version of the database schema.
     timer : `bool`, optional
         If `True` then log timing information.
     """
 
-    def __init__(self, schema: ApdbSqlSchema, engine: sqlalchemy.engine.Engine, timer: bool = False):
+    def __init__(
+        self,
+        schema: ApdbSqlSchema,
+        engine: sqlalchemy.engine.Engine,
+        db_schema_version: VersionTuple,
+        timer: bool = False,
+    ):
         self._schema = schema
         self._engine = engine
+        self._db_schema_version = db_schema_version
 
         self._timer_args: list[MonAgent | logging.Logger] = [_MON]
         if timer:
@@ -96,7 +105,7 @@ class ApdbSqlReplica(ApdbReplica):
 
     def schemaVersion(self) -> VersionTuple:
         # Docstring inherited from base class.
-        return self._schema.schemaVersion()
+        return self._db_schema_version
 
     @classmethod
     def apdbReplicaImplementationVersion(cls) -> VersionTuple:


### PR DESCRIPTION
This PR adds a method to the `ApdbReplica` interface for accessing the database schema version. Implementation methods were added to the two concrete classes which implement this interface.