### PR TITLE
DM-50796: Add support for healpix pixelization to Cassandra backend

### DIFF
--- a/python/lsst/dax/apdb/cassandra/config.py
+++ b/python/lsst/dax/apdb/cassandra/config.py
@@ -163,7 +163,7 @@ class ApdbCassandraPartitioningConfig(BaseModel):
     @field_validator("part_pixelization")
     @classmethod
     def check_pixelization(cls, v: str) -> str:
-        allowed = {"htm", "q3c", "mq3c"}
+        allowed = {"htm", "q3c", "mq3c", "healpix"}
         if v not in allowed:
             raise ValueError(f"Unexpected value for part_pixelization: {v}, allowed values: {allowed}")
         return v


### PR DESCRIPTION
Healpix does not support `maxRanges` in envelope(), which could potentially cause issues if region is too large. For APDB use case this should not be a problem as our regions are detector-size.