### PR TITLE
DM-50725: Switch to single-partition batches writes for Cassandra APDB

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -9,3 +9,5 @@ on:
 jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/mypy.yaml@main
+    with:
+      folders: "python tests"


### PR DESCRIPTION
Avoids creating multi-partition BatchStatement by either grouping statements by partition or sending multiple statements concurrently.