### PR TITLE
DM-51824: Implement management of per-partition tables in APDB

### DIFF
--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -775,8 +775,14 @@ class ApdbCassandra(Apdb):
 
         sp_where = context.partitioner.spatial_where(region, for_prepare=True)
         tables, temporal_where = context.partitioner.temporal_where(
-            table_name, mjd_start, mjd_end, for_prepare=True
+            table_name, mjd_start, mjd_end, for_prepare=True, partitons_range=context.time_partitions_range
         )
+        if not tables:
+            start = astropy.time.Time(mjd_start, format="mjd", scale="tai")
+            end = astropy.time.Time(mjd_end, format="mjd", scale="tai")
+            warnings.warn(
+                f"Query time range ({start.isot} - {end.isot}) does not overlap database time partitions."
+            )
 
         # We need to exclude extra partitioning columns from result.
         column_names = context.schema.apdbColumnNames(table_name)

--- a/python/lsst/dax/apdb/cassandra/apdbCassandra.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandra.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 __all__ = ["ApdbCassandra"]
 
 import datetime
-import json
 import logging
 import random
 import warnings
@@ -422,11 +421,7 @@ class ApdbCassandra(Apdb):
 
             # Store time partition range.
             if part_range_config:
-                metadata.set(
-                    ConnectionContext.metadataTimePartitionKey,
-                    json.dumps(part_range_config.model_dump()),
-                    force=True,
-                )
+                part_range_config.save_to_meta(metadata)
 
     def getDiaObjects(self, region: sphgeom.Region) -> pandas.DataFrame:
         # docstring is inherited from a base class

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     import cassandra.cluster
 
     from ..schema_model import Table
+    from .config import ApdbCassandraTimePartitionRange
 
 
 _LOG = logging.getLogger(__name__)
@@ -619,7 +620,7 @@ class ApdbCassandraSchema:
         self,
         *,
         drop: bool = False,
-        part_range: tuple[int, int] | None = None,
+        part_range: ApdbCassandraTimePartitionRange | None = None,
         replication_factor: int | None = None,
         table_options: CreateTableOptions | None = None,
     ) -> None:
@@ -630,11 +631,10 @@ class ApdbCassandraSchema:
         drop : `bool`
             If True then drop tables before creating new ones. Note that
             only tables are dropped and not the whole keyspace.
-        part_range : `tuple` [ `int` ] or `None`
-            Start and end partition number for time partitions, end is not
-            inclusive. Used to create per-partition DiaObject, DiaSource, and
-            DiaForcedSource tables. If `None` then per-partition tables are
-            not created.
+        part_range : `ApdbCassandraTimePartitionRange` or `None`
+            Start and end partition number for time partitions. Used to create
+            per-partition DiaObject, DiaSource, and DiaForcedSource tables. If
+            `None` then per-partition tables are not created.
         replication_factor : `int`, optional
             Replication factor used when creating new keyspace, if keyspace
             already exists its replication factor is not changed.
@@ -696,7 +696,7 @@ class ApdbCassandraSchema:
         self,
         table: ApdbTables | ExtraTables,
         drop: bool = False,
-        part_range: tuple[int, int] | None = None,
+        part_range: ApdbCassandraTimePartitionRange | None = None,
         table_options: CreateTableOptions | None = None,
     ) -> None:
         _LOG.debug("Making table %s", table)
@@ -706,7 +706,7 @@ class ApdbCassandraSchema:
         table_list = [fullTable]
         if part_range is not None:
             if table in self._time_partitioned_tables:
-                table_list = [table.table_name(self._prefix, part) for part in range(*part_range)]
+                table_list = [table.table_name(self._prefix, part) for part in part_range.range()]
 
         if drop:
             queries = [f'DROP TABLE IF EXISTS "{self._keyspace}"."{table_name}"' for table_name in table_list]

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -802,3 +802,19 @@ class ApdbCassandraSchema:
         table_schema = self._table_schema(table)
         size = sum(column.size() for column in table_schema.columns)
         return size
+
+    def time_partitioned_tables(self) -> list[ApdbTables]:
+        """Make the list of time-partitioned tables.
+
+        Returns
+        -------
+        tables : `list` [`ApdbTables`]
+            Tables the are time-partitioned.
+        """
+        if not self._time_partition_tables:
+            return []
+        has_dia_object_table = not (self._enable_replica and self._replica_skips_diaobjects)
+        tables = [ApdbTables.DiaSource, ApdbTables.DiaForcedSource]
+        if has_dia_object_table:
+            tables.append(ApdbTables.DiaObject)
+        return tables

--- a/python/lsst/dax/apdb/cassandra/config.py
+++ b/python/lsst/dax/apdb/cassandra/config.py
@@ -21,9 +21,14 @@
 
 from __future__ import annotations
 
-__all__ = ["ApdbCassandraConfig", "ApdbCassandraConnectionConfig", "ApdbCassandraPartitioningConfig"]
+__all__ = [
+    "ApdbCassandraConfig",
+    "ApdbCassandraConnectionConfig",
+    "ApdbCassandraPartitioningConfig",
+    "ApdbCassandraTimePartitionRange",
+]
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, Field, field_validator
@@ -247,3 +252,21 @@ class ApdbCassandraConfig(ApdbConfig):
         if len(vtup) != 2:
             raise ValueError("ra_dec_columns must have exactly two column names")
         return vtup
+
+
+class ApdbCassandraTimePartitionRange(BaseModel):
+    """Configuration of the time partitions, this is not user-configurable,
+    but it is reflected in metadata.
+    """
+
+    start: int = Field(
+        description="Start partition number for per-time-partition tables that exist in the schema."
+    )
+
+    end: int = Field(
+        description="End partition number (inclusive) for per-time-partition tables that exist in the schema."
+    )
+
+    def range(self) -> Iterator[int]:
+        """Generate a sequence of partition numbers."""
+        yield from range(self.start, self.end + 1)

--- a/python/lsst/dax/apdb/cassandra/connectionContext.py
+++ b/python/lsst/dax/apdb/cassandra/connectionContext.py
@@ -93,6 +93,9 @@ class ConnectionContext:
     metadataConfigKey = "config:apdb-cassandra.json"
     """Name of the metadata key to store frozen part of the configuration."""
 
+    metadataTimePartitionKey = "config:time-partition-range"
+    """Name of the metadata key to store time partition range."""
+
     frozen_parameters = (
         "enable_replica",
         "ra_dec_columns",
@@ -137,6 +140,9 @@ class ConnectionContext:
             self.has_chunk_sub_partitions = ApdbCassandraReplica.hasChunkSubPartitions(
                 self.db_versions.replica_version
             )
+
+        # Since version 0.1.3 we have metadata for time partitions.
+        self.has_time_partition_meta = self.db_versions.code_version >= VersionTuple(0, 1, 3)
 
         # Since version 0.1.2 we have an extra table for visit/detector.
         self.has_visit_detector_table = self.db_versions.code_version >= VersionTuple(0, 1, 2)

--- a/python/lsst/dax/apdb/cassandra/connectionContext.py
+++ b/python/lsst/dax/apdb/cassandra/connectionContext.py
@@ -43,7 +43,7 @@ from .apdbCassandraReplica import ApdbCassandraReplica
 from .apdbCassandraSchema import ApdbCassandraSchema
 from .apdbMetadataCassandra import ApdbMetadataCassandra
 from .cassandra_utils import PreparedStatementCache
-from .config import ApdbCassandraConfig
+from .config import ApdbCassandraConfig, ApdbCassandraTimePartitionRange
 from .partitioner import Partitioner
 
 _LOG = logging.getLogger(__name__)
@@ -92,9 +92,6 @@ class ConnectionContext:
 
     metadataConfigKey = "config:apdb-cassandra.json"
     """Name of the metadata key to store frozen part of the configuration."""
-
-    metadataTimePartitionKey = "config:time-partition-range"
-    """Name of the metadata key to store time partition range."""
 
     frozen_parameters = (
         "enable_replica",
@@ -166,6 +163,27 @@ class ConnectionContext:
             has_chunk_sub_partitions=self.has_chunk_sub_partitions,
             has_visit_detector_table=self.has_visit_detector_table,
         )
+
+    @property
+    def time_partitions_range(self) -> ApdbCassandraTimePartitionRange | None:
+        """Time partition range or None if instance does not use
+        time-partitioned tables (`ApdbCassandraTimePartitionRange` or `None`).
+        """
+        if not self.config.partitioning.time_partition_tables:
+            return None
+
+        if self.has_time_partition_meta:
+            return ApdbCassandraTimePartitionRange.from_meta(self.metadata)
+        else:
+            # Scan DiaSource tables and see which partitions are present.
+            partitions = set()
+            tables = self.schema.existing_tables(ApdbTables.DiaSource)
+            for table_name in tables[ApdbTables.DiaSource]:
+                _, _, part_str = table_name.rpartition("_")
+                partitions.add(int(part_str))
+            if not partitions:
+                raise LookupError("Failed to find any partitioned DiaSource table.")
+            return ApdbCassandraTimePartitionRange(start=min(partitions), end=max(partitions))
 
     def _readVersions(self, metadata: ApdbMetadataCassandra) -> DbVersions:
         """Read versions of all objects from metadata."""

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -283,6 +283,7 @@ def _partition_subcommand(subparsers: argparse._SubParsersAction) -> None:
     subparsers = parser.add_subparsers(title="available subcommands", required=True)
     _partition_show_temporal(subparsers)
     _partition_extend_temporal(subparsers)
+    _partition_delete_temporal(subparsers)
 
 
 def _partition_show_temporal(subparsers: argparse._SubParsersAction) -> None:
@@ -304,3 +305,17 @@ def _partition_extend_temporal(subparsers: argparse._SubParsersAction) -> None:
         help="Max. number of days for extension, default: %(default)s.",
     )
     parser.set_defaults(method=scripts.partition_extend_temporal)
+
+
+def _partition_delete_temporal(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("delete-temporal", help="Delete temporal partitions.")
+    parser.add_argument("apdb_config", help="Path to the APDB configuration.")
+    parser.add_argument("time", help="Timestamps in ISOT format and TAI scale (YYYY-MM-DD[THH:MM:SS]).")
+    parser.add_argument(
+        "--after",
+        action="store_true",
+        default=False,
+        help="Delete partitions after specified time. Default is to delete partitions before this time.",
+    )
+    parser.add_argument("--force", action="store_true", default=False, help="Do not ask for confirmation.")
+    parser.set_defaults(method=scripts.partition_delete_temporal)

--- a/python/lsst/dax/apdb/cli/apdb_cli.py
+++ b/python/lsst/dax/apdb/cli/apdb_cli.py
@@ -46,6 +46,7 @@ def main(args: Sequence[str] | None = None) -> int | None:
     _convert_legacy_config_subcommand(subparsers)
     _metrics_subcommand(subparsers)
     _replication_subcommand(subparsers)
+    _partition_subcommand(subparsers)
 
     parsed_args = parser.parse_args(args)
     log_cli.process_args(parsed_args)
@@ -275,3 +276,31 @@ def _replication_delete_chunks_subcommand(subparsers: argparse._SubParsersAction
         default=False,
     )
     parser.set_defaults(method=scripts.replication_delete_chunks)
+
+
+def _partition_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("partition", help="Operations with APDB partitioning.")
+    subparsers = parser.add_subparsers(title="available subcommands", required=True)
+    _partition_show_temporal(subparsers)
+    _partition_extend_temporal(subparsers)
+
+
+def _partition_show_temporal(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("show-temporal", help="Print range of temporal partitions.")
+    parser.add_argument("apdb_config", help="Path to the APDB configuration.")
+    parser.set_defaults(method=scripts.partition_show_temporal)
+
+
+def _partition_extend_temporal(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("extend-temporal", help="Extend the range of temporal partitions.")
+    parser.add_argument("apdb_config", help="Path to the APDB configuration.")
+    parser.add_argument("time", help="Timestamps in ISOT format and TAI scale (YYYY-MM-DDTHH:MM:SS).")
+    parser.add_argument("--past", action="store_true", default=False, help="Extend the range in the past.")
+    parser.add_argument(
+        "--max-days",
+        type=int,
+        default=365,
+        metavar="NUMBER",
+        help="Max. number of days for extension, default: %(default)s.",
+    )
+    parser.set_defaults(method=scripts.partition_extend_temporal)

--- a/python/lsst/dax/apdb/scripts/__init__.py
+++ b/python/lsst/dax/apdb/scripts/__init__.py
@@ -27,5 +27,5 @@ from .list_cassandra import list_cassandra
 from .list_index import list_index
 from .metadata import metadata_delete, metadata_get, metadata_set, metadata_show
 from .metrics import metrics_log_to_influx
-from .partition import partition_extend_temporal, partition_show_temporal
+from .partition import partition_delete_temporal, partition_extend_temporal, partition_show_temporal
 from .replication import replication_delete_chunks, replication_list_chunks

--- a/python/lsst/dax/apdb/scripts/__init__.py
+++ b/python/lsst/dax/apdb/scripts/__init__.py
@@ -27,4 +27,5 @@ from .list_cassandra import list_cassandra
 from .list_index import list_index
 from .metadata import metadata_delete, metadata_get, metadata_set, metadata_show
 from .metrics import metrics_log_to_influx
+from .partition import partition_extend_temporal, partition_show_temporal
 from .replication import replication_delete_chunks, replication_list_chunks

--- a/python/lsst/dax/apdb/scripts/partition.py
+++ b/python/lsst/dax/apdb/scripts/partition.py
@@ -1,0 +1,115 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["partition_extend_temporal", "partition_show_temporal"]
+
+import sys
+
+import astropy.time
+
+from ..apdb import Apdb
+from ..cassandra import ApdbCassandra
+
+
+def partition_show_temporal(apdb_config: str) -> int:
+    """Print range of temporal partitions.
+
+    Parameters
+    ----------
+    apdb_config : `str`
+        URL for APDB configuration file.
+    """
+    apdb = Apdb.from_uri(apdb_config)
+    if not isinstance(apdb, ApdbCassandra):
+        print("ERROR: Non-Cassandra APDB does not use time-partitioned tables.", file=sys.stderr)
+        return 1
+
+    admin = apdb.admin
+    try:
+        part_range = admin.time_partitions()
+    except TypeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    start_time, _ = admin.partitioner.partition_period(part_range.start)
+    _, end_time = admin.partitioner.partition_period(part_range.end)
+
+    print(
+        f"Current time partition range: {part_range.start} - {part_range.end} "
+        f"[{start_time.tai.isot}, {end_time.tai.isot})"
+    )
+
+    return 0
+
+
+def partition_extend_temporal(apdb_config: str, time: str, past: bool, max_days: int) -> int:
+    """Extend the range of temporal partitions.
+
+    Parameters
+    ----------
+    apdb_config : `str`
+        URL for APDB configuration file.
+    time : `str`
+        Timestamps in ISOT format and TAI scale.
+    past : `bool`
+        If `True` extend the range in the past.
+    max_days : `int`
+        Max. number of days for extension.
+    """
+    try:
+        astro_time = astropy.time.Time(time, format="isot", scale="tai")
+        max_delta = astropy.time.TimeDelta(float(max_days), format="jd", scale="tai")
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    apdb = Apdb.from_uri(apdb_config)
+    if not isinstance(apdb, ApdbCassandra):
+        print("ERROR: Non-Cassandra APDB does not use time-partitioned tables.", file=sys.stderr)
+        return 1
+
+    admin = apdb.admin
+    try:
+        result = admin.extend_time_partitions(astro_time, forward=not past, max_delta=max_delta)
+    except (TypeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    part_range = admin.time_partitions()
+    start_time, _ = admin.partitioner.partition_period(part_range.start)
+    _, end_time = admin.partitioner.partition_period(part_range.end)
+
+    if result:
+        print(
+            "Time partition range succesfully extended.\n"
+            f"New time partition range: {part_range.start} - {part_range.end} "
+            f"[{start_time.tai.isot}, {end_time.tai.isot})"
+        )
+    else:
+        print(
+            "Time partition range was not extended.\n"
+            f"Current time partition range: {part_range.start} - {part_range.end} "
+            f"[{start_time.tai.isot}, {end_time.tai.isot})"
+        )
+
+    return 0

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -122,7 +122,6 @@ class ApdbTest(TestCaseMixin, ABC):
     calls various assert methods.
     """
 
-    time_partition_tables = False
     visit_time = astropy.time.Time("2021-01-01T00:00:00", format="isot", scale="tai")
 
     fsrc_requires_id_list = False
@@ -139,6 +138,9 @@ class ApdbTest(TestCaseMixin, ABC):
 
     extra_chunk_columns = 1
     """Number of additional columns in chunk tables."""
+
+    meta_row_count = 3
+    """Initial row count in metadata table."""
 
     # number of columns as defined in tests/config/schema.yaml
     table_column_count = {
@@ -687,8 +689,7 @@ class ApdbTest(TestCaseMixin, ABC):
         # APDB should write two or three metadata items with version numbers
         # and a frozen JSON config.
         self.assertFalse(metadata.empty())
-        expected_rows = 4 if self.enable_replica else 3
-        self.assertEqual(len(list(metadata.items())), expected_rows)
+        self.assertEqual(len(list(metadata.items())), self.meta_row_count)
 
         metadata.set("meta", "data")
         metadata.set("data", "meta")

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -27,7 +27,6 @@ import contextlib
 import datetime
 import os
 import tempfile
-import unittest
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from tempfile import TemporaryDirectory
@@ -50,17 +49,10 @@ from .. import (
     VersionTuple,
 )
 from .data_factory import makeForcedSourceCatalog, makeObjectCatalog, makeSourceCatalog, makeSSObjectCatalog
+from .utils import TestCaseMixin
 
 if TYPE_CHECKING:
     from ..pixelization import Pixelization
-
-    class TestCaseMixin(unittest.TestCase):
-        """Base class for mixin test classes that use TestCase methods."""
-
-else:
-
-    class TestCaseMixin:
-        """Do-nothing definition of mixin base class for regular execution."""
 
 
 def _make_region(xyz: tuple[float, float, float] = (1.0, 1.0, -1.0)) -> Region:

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -196,6 +196,10 @@ class ApdbTest(TestCaseMixin, ABC):
             len(catalog.column_names()), self.table_column_count[table] + self.extra_chunk_columns
         )
 
+    def make_region(self, xyz: tuple[float, float, float] = (1.0, 1.0, -1.0)) -> Region:
+        """Make a region to use in tests"""
+        return _make_region(xyz)
+
     def test_makeSchema(self) -> None:
         """Test for making APDB schema."""
         config = self.make_instance()
@@ -228,7 +232,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         res: pandas.DataFrame | None
@@ -277,7 +281,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance(read_sources_months=0, read_forced_sources_months=0)
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         res: pandas.DataFrame | None
@@ -308,7 +312,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         # make catalog with Objects
@@ -327,7 +331,7 @@ class ApdbTest(TestCaseMixin, ABC):
         """Test calling storeObject when there are no objects: see DM-43270."""
         config = self.make_instance()
         apdb = Apdb.from_config(config)
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
         # make catalog with no Objects
         catalog = makeObjectCatalog(region, 0, visit_time)
@@ -375,7 +379,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         # have to store Objects first
@@ -411,7 +415,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         # have to store Objects first
@@ -441,7 +445,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         # have to store Objects first
@@ -475,8 +479,8 @@ class ApdbTest(TestCaseMixin, ABC):
         apdb_replica = ApdbReplica.from_config(config)
         visit_time = self.visit_time
 
-        region1 = _make_region((1.0, 1.0, -1.0))
-        region2 = _make_region((-1.0, -1.0, -1.0))
+        region1 = self.make_region((1.0, 1.0, -1.0))
+        region2 = self.make_region((-1.0, -1.0, -1.0))
         nobj = 100
         objects1 = makeObjectCatalog(region1, nobj, visit_time)
         objects2 = makeObjectCatalog(region2, nobj, visit_time, start_id=nobj * 2)
@@ -572,7 +576,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
         objects = makeObjectCatalog(region, 100, visit_time)
         oids = list(objects["diaObjectId"])
@@ -604,7 +608,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         # 2021-01-01 plus 360 days is 2021-12-27
         src_time1 = astropy.time.Time("2021-01-01T00:00:00", format="isot", scale="tai")
         src_time2 = astropy.time.Time("2021-01-01T00:00:02", format="isot", scale="tai")
@@ -641,7 +645,7 @@ class ApdbTest(TestCaseMixin, ABC):
         config = self.make_instance()
         apdb = Apdb.from_config(config)
 
-        region = _make_region()
+        region = self.make_region()
         src_time1 = astropy.time.Time("2021-01-01T00:00:00", format="isot", scale="tai")
         src_time2 = astropy.time.Time("2021-01-01T00:00:02", format="isot", scale="tai")
         visit_time0 = astropy.time.Time("2021-12-26T23:59:59", format="isot", scale="tai")
@@ -752,6 +756,10 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         """
         raise NotImplementedError()
 
+    def make_region(self, xyz: tuple[float, float, float] = (1.0, 1.0, -1.0)) -> Region:
+        """Make a region to use in tests"""
+        return _make_region(xyz)
+
     def test_schema_add_replica(self) -> None:
         """Check that new code can work with old schema without replica
         tables.
@@ -766,7 +774,7 @@ class ApdbSchemaUpdateTest(TestCaseMixin, ABC):
         apdb = Apdb.from_config(config)
 
         # Try to insert something, should work OK.
-        region = _make_region()
+        region = self.make_region()
         visit_time = self.visit_time
 
         # have to store Objects first

--- a/python/lsst/dax/apdb/tests/_apdb_admin.py
+++ b/python/lsst/dax/apdb/tests/_apdb_admin.py
@@ -19,6 +19,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import data_factory
-from ._apdb import *
-from ._apdb_admin import *
+from __future__ import annotations
+
+__all__ = ["ApdbAdminTest"]
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from .. import ApdbConfig
+from .utils import TestCaseMixin
+
+
+class ApdbAdminTest(TestCaseMixin, ABC):
+    """Base class for ApdbAdmin tests that can be specialized for concrete
+    implementation.
+
+    This can only be used as a mixin class for a unittest.TestCase and it
+    calls various assert methods.
+
+    There are no common test methods in this class yet, they may be added in
+    the future.
+    """
+
+    @abstractmethod
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
+        """Make database instance and return configuration for it."""
+        raise NotImplementedError()

--- a/python/lsst/dax/apdb/tests/cassandra_mixin.py
+++ b/python/lsst/dax/apdb/tests/cassandra_mixin.py
@@ -1,0 +1,66 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ApdbCassandraMixin"]
+
+import os
+import unittest
+import uuid
+
+try:
+    import cassandra  # noqa: F401
+
+    CASSANDRA_IMPORTED = True
+except ImportError:
+    CASSANDRA_IMPORTED = False
+
+from ..cassandra.apdbCassandraAdmin import ApdbCassandraAdmin
+from .utils import TestCaseMixin
+
+
+class ApdbCassandraMixin(TestCaseMixin):
+    """Mixin class which defines common methods for unit tests."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Prepare config for server connection."""
+        if not CASSANDRA_IMPORTED:
+            raise unittest.SkipTest("Failed to import Cassandra modules")
+        cluster_host = os.environ.get("DAX_APDB_TEST_CASSANDRA_CLUSTER")
+        if not cluster_host:
+            raise unittest.SkipTest("DAX_APDB_TEST_CASSANDRA_CLUSTER is not set")
+        if not CASSANDRA_IMPORTED:
+            raise unittest.SkipTest("cassandra_driver cannot be imported")
+
+    def setUp(self) -> None:
+        """Prepare config for server connection."""
+        self.cluster_host = os.environ.get("DAX_APDB_TEST_CASSANDRA_CLUSTER")
+        # Use dedicated keyspace for each test, keyspace is created by
+        # init_database if it does not exist.
+        key = uuid.uuid4()
+        self.keyspace = f"apdb_{key.hex}"
+
+    def tearDown(self) -> None:
+        # Delete per-test keyspace.
+        assert self.cluster_host is not None
+        ApdbCassandraAdmin.delete_database(self.cluster_host, self.keyspace)

--- a/python/lsst/dax/apdb/tests/utils.py
+++ b/python/lsst/dax/apdb/tests/utils.py
@@ -19,6 +19,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import data_factory
-from ._apdb import *
-from ._apdb_admin import *
+from __future__ import annotations
+
+import unittest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+
+    class TestCaseMixin(unittest.TestCase):
+        """Base class for mixin test classes that use TestCase methods."""
+
+else:
+
+    class TestCaseMixin:
+        """Do-nothing definition of mixin base class for regular execution."""

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -99,8 +99,8 @@ class ApdbCassandraPerMonthTestCase(ApdbCassandraTestCase):
     """A test case for ApdbCassandra class with per-month tables."""
 
     time_partition_tables = True
-    time_partition_start = "2019-12-01T00:00:00"
-    time_partition_end = "2022-01-01T00:00:00"
+    time_partition_start = "2020-06-01T00:00:00"
+    time_partition_end = "2021-06-01T00:00:00"
     meta_row_count = 4
 
 

--- a/tests/test_apdbCassandra.py
+++ b/tests/test_apdbCassandra.py
@@ -65,6 +65,8 @@ class ApdbCassandraMixin:
 
     schema_path = TEST_SCHEMA
 
+    time_partition_tables = False
+
     @classmethod
     def setUpClass(cls) -> None:
         """Prepare config for server connection."""
@@ -118,7 +120,6 @@ class ApdbCassandraMixin:
 class ApdbCassandraTestCase(ApdbCassandraMixin, ApdbTest, unittest.TestCase):
     """A test case for ApdbCassandra class"""
 
-    time_partition_tables = False
     time_partition_start: str | None = None
     time_partition_end: str | None = None
     # Cassandra stores timestamps with millisecond precision internally,
@@ -153,12 +154,14 @@ class ApdbCassandraPerMonthTestCase(ApdbCassandraTestCase):
     time_partition_tables = True
     time_partition_start = "2019-12-01T00:00:00"
     time_partition_end = "2022-01-01T00:00:00"
+    meta_row_count = 4
 
 
 class ApdbCassandraTestCaseReplica(ApdbCassandraTestCase):
     """A test case  with enabled replica tables."""
 
     enable_replica = True
+    meta_row_count = 4
 
 
 class ApdbSchemaUpdateCassandraTestCase(ApdbCassandraMixin, ApdbSchemaUpdateTest, unittest.TestCase):
@@ -170,7 +173,7 @@ class ApdbSchemaUpdateCassandraTestCase(ApdbCassandraMixin, ApdbSchemaUpdateTest
             "hosts": (self.cluster_host,),
             "keyspace": self.keyspace,
             "schema_file": TEST_SCHEMA,
-            "time_partition_tables": False,
+            "time_partition_tables": self.time_partition_tables,
         }
         kw.update(kwargs)
         return ApdbCassandra.init_database(**kw)  # type: ignore[arg-type]

--- a/tests/test_apdbCassandraAdmin.py
+++ b/tests/test_apdbCassandraAdmin.py
@@ -1,0 +1,154 @@
+# This file is part of dax_apdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit test for `ApdbCassandraAdmin` class.
+
+Notes
+-----
+For now this test can only run against actual Cassandra cluster, to specify
+cluster location use ``DAX_APDB_TEST_CASSANDRA_CLUSTER`` environment variable,
+e.g.:
+
+    export DAX_APDB_TEST_CASSANDRA_CLUSTER=cassandra.example.com
+    pytest tests/test_apdbCassandra.py
+
+Individual tests create and destroy unique keyspaces in the cluster, there is
+no need to pre-create a keyspace with predefined name.
+"""
+
+import logging
+import os
+import unittest
+from typing import Any, cast
+
+import astropy.time
+
+from lsst.dax.apdb import Apdb, ApdbConfig
+from lsst.dax.apdb.cassandra import ApdbCassandra
+from lsst.dax.apdb.cassandra.apdbCassandraAdmin import ApdbCassandraAdmin
+from lsst.dax.apdb.tests import ApdbAdminTest, cassandra_mixin
+
+TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/schema.yaml")
+
+logging.basicConfig(level=logging.INFO)
+
+
+class ApdbCassandraAdminTestCase(cassandra_mixin.ApdbCassandraMixin, ApdbAdminTest, unittest.TestCase):
+    """A test case for ApdbCassandraAdmin class."""
+
+    schema_path = TEST_SCHEMA
+    time_partition_tables = False
+    time_partition_start: str | None = None
+    time_partition_end: str | None = None
+
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
+        """Make config class instance used in all tests."""
+        kw: dict[str, Any] = {
+            "hosts": (self.cluster_host,),
+            "keyspace": self.keyspace,
+            "schema_file": TEST_SCHEMA,
+            "time_partition_tables": self.time_partition_tables,
+        }
+        if self.time_partition_start:
+            kw["time_partition_start"] = self.time_partition_start
+        if self.time_partition_end:
+            kw["time_partition_end"] = self.time_partition_end
+        kw.update(kwargs)
+        return ApdbCassandra.init_database(**kw)
+
+    def make_admin(self) -> ApdbCassandraAdmin:
+        """Make ApdbCassandraAdmin instance."""
+        config = self.make_instance()
+        apdb = cast(ApdbCassandra, Apdb.from_config(config))
+        return apdb.admin
+
+    def test_extend_time_partitions(self) -> None:
+        """Test extend_time_partitions() method."""
+        admin = self.make_admin()
+
+        self._test_extend_time_partitions(admin)
+
+    def _test_extend_time_partitions(self, admin: ApdbCassandraAdmin) -> None:
+        """Implement test_extend_time_partitions, to be specialized in
+        subclasses.
+        """
+        with self.assertRaisesRegex(TypeError, "does not use time-partitioned tables"):
+            admin.time_partitions()
+        with self.assertRaisesRegex(TypeError, "does not use time-partitioned tables"):
+            admin.extend_time_partitions(astropy.time.Time("2020-01-01T00:00:00Z", format="isot"))
+
+
+class ApdbCassandraAdminTimePartitionedTestCase(ApdbCassandraAdminTestCase):
+    """A test case for ApdbCassandraAdmin class with per-month tables."""
+
+    time_partition_tables = True
+    time_partition_start = "2025-01-01T00:00:00"
+    time_partition_end = "2026-01-01T00:00:00"
+
+    def _test_extend_time_partitions(self, admin: ApdbCassandraAdmin) -> None:
+        time_part = admin.time_partitions()
+        self.assertEqual((time_part.start, time_part.end), (669, 681))
+
+        # Test too long range first.
+        with self.assertRaisesRegex(ValueError, "Extension exceeds limit"):
+            admin.extend_time_partitions(astropy.time.Time("2027-02-02T00:00:00Z", format="isot"))
+        with self.assertRaisesRegex(ValueError, "Extension exceeds limit"):
+            admin.extend_time_partitions(
+                astropy.time.Time("2023-11-25T00:00:00Z", format="isot"), forward=False
+            )
+
+        # Nothing to do.
+        self.assertFalse(
+            admin.extend_time_partitions(astropy.time.Time("2024-01-01T00:00:00Z", format="isot"))
+        )
+        self.assertFalse(
+            admin.extend_time_partitions(
+                astropy.time.Time("2027-01-01T00:00:00Z", format="isot"), forward=False
+            )
+        )
+        time_part = admin.time_partitions()
+        self.assertEqual((time_part.start, time_part.end), (669, 681))
+
+        self.assertTrue(
+            admin.extend_time_partitions(astropy.time.Time("2026-12-01T00:00:00Z", format="isot"))
+        )
+        time_part = admin.time_partitions()
+        self.assertEqual((time_part.start, time_part.end), (669, 692))
+        self.assertTrue(
+            admin.extend_time_partitions(
+                astropy.time.Time("2024-02-01T00:00:00Z", format="isot"), forward=False
+            )
+        )
+        time_part = admin.time_partitions()
+        self.assertEqual((time_part.start, time_part.end), (658, 692))
+
+
+class ApdbCassandraAdminNoDiaObjectTestCase(ApdbCassandraAdminTimePartitionedTestCase):
+    """A test case for ApdbCassandraAdmin with replica table and no DiaObject
+    table.
+    """
+
+    def make_instance(self, **kwargs: Any) -> ApdbConfig:
+        return super().make_instance(enable_replica=True, replica_skips_diaobjects=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_apdbSql.py
+++ b/tests/test_apdbSql.py
@@ -120,6 +120,7 @@ class ApdbSQLiteTestCaseReplica(ApdbSQLiteTestCase):
     """Test case for ApdbSql class using SQLite backend with replica tables."""
 
     enable_replica = True
+    meta_row_count = 4
 
 
 @unittest.skipUnless(testing is not None, "testing.postgresql module not found")
@@ -130,6 +131,7 @@ class ApdbPostgresTestCase(ApdbSQLTest, unittest.TestCase):
     dia_object_index = "last_object_table"
     postgresql: Any
     enable_replica = True
+    meta_row_count = 4
     schema_path = TEST_SCHEMA
     timestamp_type_name = "datetime64[ns]"
 


### PR DESCRIPTION
Added new CLI tools to extend/shrink range of time partitions for time-partitioned tables.

This changes patch-level version of ApdbCassandra class. There is no actual schema change, the only difference is we now store current time partition range in metadata table.