### PR TITLE
DM-52233: Provide access to SSSource table schema

### DIFF
--- a/python/lsst/dax/apdb/apdbSchema.py
+++ b/python/lsst/dax/apdb/apdbSchema.py
@@ -88,6 +88,9 @@ class ApdbTables(enum.Enum):
     SSObject = "SSObject"
     """Name of the table for SSObject records."""
 
+    SSSource = "SSSource"
+    """Name of the table for SSSource records."""
+
     DiaObject_To_Object_Match = "DiaObject_To_Object_Match"
     """Name of the table for DiaObject_To_Object_Match records."""
 

--- a/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
+++ b/python/lsst/dax/apdb/cassandra/apdbCassandraSchema.py
@@ -669,6 +669,9 @@ class ApdbCassandraSchema:
         for table in self._apdb_tables:
             if table is ApdbTables.DiaObject and self._enable_replica and self._replica_skips_diaobjects:
                 continue
+            if table is ApdbTables.SSSource:
+                # We do not support SSSource table yet.
+                continue
             self._makeTableSchema(table, drop, part_range, table_options)
         for extra_table in self._extra_tables:
             self._makeTableSchema(extra_table, drop, part_range, table_options)

--- a/python/lsst/dax/apdb/sql/apdbSqlSchema.py
+++ b/python/lsst/dax/apdb/sql/apdbSqlSchema.py
@@ -325,12 +325,15 @@ class ApdbSqlSchema(ApdbSchema):
         mysql_engine : `str`, optional
             MySQL engine type to use for new tables.
         """
-        tables = {}
+        tables: dict[ApdbTables, schema_model.Table] = {}
         for table_enum in ApdbTables:
             if table_enum is ApdbTables.DiaObjectLast and self._dia_object_index != "last_object_table":
                 continue
             if table_enum is ApdbTables.metadata and table_enum not in self.tableSchemas:
                 # Schema does not define metadata.
+                continue
+            if table_enum is ApdbTables.SSSource:
+                # We do not support SSSource table yet.
                 continue
             table = self.tableSchemas[table_enum]
             tables[table_enum] = table

--- a/python/lsst/dax/apdb/tests/_apdb.py
+++ b/python/lsst/dax/apdb/tests/_apdb.py
@@ -216,6 +216,9 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaSource))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaForcedSource))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.metadata))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.SSObject))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.SSSource))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject_To_Object_Match))
 
         # Test from_uri factory method with the same config.
         with tempfile.NamedTemporaryFile() as tmpfile:
@@ -227,6 +230,9 @@ class ApdbTest(TestCaseMixin, ABC):
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaSource))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaForcedSource))
         self.assertIsNotNone(apdb.tableDef(ApdbTables.metadata))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.SSObject))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.SSSource))
+        self.assertIsNotNone(apdb.tableDef(ApdbTables.DiaObject_To_Object_Match))
 
     def test_empty_gets(self) -> None:
         """Test for getting data from empty database.

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -341,3 +341,30 @@ tables:
     nullable: false
     description: Total number of DiaSources associated with this DiaObject.
   primaryKey: "#DiaObjectLast.diaObjectId"
+- name: SSSource
+  "@id": "#SSSource"
+  description: LSST-computed per-source quantities. 1:1 relationship with DIASource.
+    Recomputed daily, upon MPCORB ingestion.
+  primaryKey: "#SSSource.ssObjectId"
+  columns:
+  - name: ssObjectId
+    "@id": "#SSSource.ssObjectId"
+    datatype: long
+    autoincrement: false
+    description: Unique identifier of the object.
+    ivoa:ucd: meta.id;src
+  - name: diaSourceId
+    "@id": "#SSSource.diaSourceId"
+    datatype: long
+    description: Unique identifier of the observation.
+    ivoa:ucd: meta.id;src
+  - name: eclipticLambda
+    "@id": "#SSSource.eclipticLambda"
+    datatype: double
+    description: Ecliptic longitude.
+    fits:tunit: deg
+  - name: eclipticBeta
+    "@id": "#SSSource.eclipticBeta"
+    datatype: double
+    description: Ecliptic latitude.
+    fits:tunit: deg


### PR DESCRIPTION
Apdb.tableDef() now works for SSSource table as well. The table still does not exis in database schema, it may be added later.