### PR TITLE
DM-54070: Add methods to `ApdbUpdateRecord` for a getting record ID and payload values

### DIFF
--- a/python/lsst/dax/apdb/apdbUpdateRecord.py
+++ b/python/lsst/dax/apdb/apdbUpdateRecord.py
@@ -33,7 +33,7 @@ __all__ = [
 
 import dataclasses
 import json
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, ClassVar
@@ -121,6 +121,37 @@ class ApdbUpdateRecord(ABC):
         data["update_type"] = self.update_type
         return json.dumps(data)
 
+    @abstractmethod
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        """Return a tuple of (field name, field value) pairs for fields that
+        identify the record to which this update applies.
+
+        Returns
+        -------
+        record_id_tuple : `tuple` [`tuple` [`str`, `int`], ...]
+            Tuple of (field name, field value) pairs for fields that identify
+            the record to which this update applies.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        """Return a tuple of (field name, field value) pairs for fields that
+        represent updates being applied by this record.
+
+        Returns
+        -------
+        payload_tuple : `tuple` [`tuple` [`str`, `Any`], ...]
+            Tuple of (field name, field value) pairs.
+
+        Notes
+        -----
+        Returned tuple contains the fields that are actually updated. Even if
+        this class represents an update that modifies multiple fields,
+        individual records can update a smaller set of fields.
+        """
+        raise NotImplementedError()
+
 
 @dataclass(kw_only=True)
 class ApdbReassignDiaSourceToDiaObjectRecord(
@@ -134,6 +165,14 @@ class ApdbReassignDiaSourceToDiaObjectRecord(
     """ID of a new associated DIAObject record."""
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaSource
+
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (("diaSourceId", self.diaSourceId),)
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        return (("diaObjectId", self.diaObjectId),)
 
 
 @dataclass(kw_only=True)
@@ -150,6 +189,17 @@ class ApdbReassignDiaSourceToSSObjectRecord(
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaSource
 
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (("diaSourceId", self.diaSourceId),)
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        return (
+            ("ssObjectId", self.ssObjectId),
+            ("ssObjectReassocTimeMjdTai", self.ssObjectReassocTimeMjdTai),
+        )
+
 
 @dataclass(kw_only=True)
 class ApdbWithdrawDiaSourceRecord(ApdbUpdateRecord, DiaSourceId, update_type="withdraw_diasource"):
@@ -159,6 +209,14 @@ class ApdbWithdrawDiaSourceRecord(ApdbUpdateRecord, DiaSourceId, update_type="wi
     """Time when this record was marked invalid."""
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaSource
+
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (("diaSourceId", self.diaSourceId),)
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        return (("timeWithdrawnMjdTai", self.timeWithdrawnMjdTai),)
 
 
 @dataclass(kw_only=True)
@@ -171,6 +229,18 @@ class ApdbWithdrawDiaForcedSourceRecord(
     """Time when this record was marked invalid."""
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaForcedSource
+
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (
+            ("diaObjectId", self.diaObjectId),
+            ("visit", self.visit),
+            ("detector", self.detector),
+        )
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        return (("timeWithdrawnMjdTai", self.timeWithdrawnMjdTai),)
 
 
 @dataclass(kw_only=True)
@@ -187,6 +257,18 @@ class ApdbCloseDiaObjectValidityRecord(ApdbUpdateRecord, DiaObjectId, update_typ
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaObject
 
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (("diaObjectId", self.diaObjectId),)
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        payload: tuple[tuple[str, Any], ...] = (("validityEndMjdTai", self.validityEndMjdTai),)
+        # nDiaSources is updated only when not None.
+        if self.nDiaSources is not None:
+            payload += (("nDiaSources", self.nDiaSources),)
+        return payload
+
 
 @dataclass(kw_only=True)
 class ApdbUpdateNDiaSourcesRecord(ApdbUpdateRecord, DiaObjectId, update_type="update_n_dia_sources"):
@@ -198,3 +280,11 @@ class ApdbUpdateNDiaSourcesRecord(ApdbUpdateRecord, DiaObjectId, update_type="up
     """New value for nDiaSources column for updated record."""
 
     apdb_table: ClassVar[ApdbTables] = ApdbTables.DiaObject
+
+    def record_id(self) -> tuple[tuple[str, int], ...]:
+        # Docstring inherited from the base class.
+        return (("diaObjectId", self.diaObjectId),)
+
+    def record_payload(self) -> tuple[tuple[str, Any], ...]:
+        # Docstring inherited from the base class.
+        return (("nDiaSources", self.nDiaSources),)

--- a/tests/test_updateRecord.py
+++ b/tests/test_updateRecord.py
@@ -39,6 +39,20 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
     update_time_ns1 = 2_000_000_000_000_000_000
     update_time_ns2 = 2_000_000_001_000_000_000
 
+    def test_all_types(self) -> None:
+        """Test that we know full set of update types."""
+        self.assertEqual(
+            set(ApdbUpdateRecord._update_types),
+            {
+                "reassign_diasource_to_diaobject",
+                "reassign_diasource_to_ssobject",
+                "withdraw_diasource",
+                "withdraw_diaforcedsource",
+                "close_diaobject_validity",
+                "update_n_dia_sources",
+            },
+        )
+
     def test_reassign_diasource_to_ssobject(self) -> None:
         """Test round-tripping ApdbReassignDiaSourceToSSObjectRecord class."""
         record = ApdbReassignDiaSourceToSSObjectRecord(
@@ -51,6 +65,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             dec=-45.0,
             midpointMjdTai=59999.0,
         )
+        self.assertEqual(record.record_id(), (("diaSourceId", 123456),))
+        self.assertEqual(record.record_payload(), (("ssObjectId", 1), ("ssObjectReassocTimeMjdTai", 60000.0)))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(
@@ -81,6 +98,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             dec=-45.0,
             midpointMjdTai=59999.0,
         )
+        self.assertEqual(record.record_id(), (("diaSourceId", 123456),))
+        self.assertEqual(record.record_payload(), (("diaObjectId", 321),))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(
@@ -110,6 +130,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             ra=45.0,
             dec=-45.0,
         )
+        self.assertEqual(record.record_id(), (("diaObjectId", 321),))
+        self.assertEqual(record.record_payload(), (("validityEndMjdTai", 60000.0),))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(
@@ -128,6 +151,19 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
         self.assertIsInstance(record2, ApdbCloseDiaObjectValidityRecord)
         self.assertEqual(record2, record)
 
+        # Also check record_payload with nDiaSources != None
+        record = ApdbCloseDiaObjectValidityRecord(
+            update_time_ns=self.update_time_ns1,
+            update_order=0,
+            diaObjectId=321,
+            validityEndMjdTai=60000.0,
+            nDiaSources=3,
+            ra=45.0,
+            dec=-45.0,
+        )
+        self.assertEqual(record.record_id(), (("diaObjectId", 321),))
+        self.assertEqual(record.record_payload(), (("validityEndMjdTai", 60000.0), ("nDiaSources", 3)))
+
     def test_update_n_dia_sources(self) -> None:
         """Test round-tripping ApdbUpdateNDiaSourcesRecord class."""
         record = ApdbUpdateNDiaSourcesRecord(
@@ -138,6 +174,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             ra=45.0,
             dec=-45.0,
         )
+        self.assertEqual(record.record_id(), (("diaObjectId", 321),))
+        self.assertEqual(record.record_payload(), (("nDiaSources", 6),))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(
@@ -166,6 +205,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             dec=-45.0,
             midpointMjdTai=60000.0,
         )
+        self.assertEqual(record.record_id(), (("diaSourceId", 123456),))
+        self.assertEqual(record.record_payload(), (("timeWithdrawnMjdTai", 61000.0),))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(
@@ -197,6 +239,9 @@ class ApdbUpdateRecordTestCase(unittest.TestCase):
             dec=-45.0,
             midpointMjdTai=60000.0,
         )
+        self.assertEqual(record.record_id(), (("diaObjectId", 1234), ("visit", 555), ("detector", 123)))
+        self.assertEqual(record.record_payload(), (("timeWithdrawnMjdTai", 61000.0),))
+
         record_json = record.to_json()
         record_dict = json.loads(record_json)
         self.assertEqual(


### PR DESCRIPTION
This adds some methods to `ApdbUpdateRecord` for getting the record ID and payload values. They fields are annotated with `dataclasses` metadata, so that they can be retrieved generically.

**TODO**

- [x] Need to add tests of the new functionality